### PR TITLE
fix issue with delimiter dropdown

### DIFF
--- a/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Properties/PublishProfiles/FolderProfile.pubxml
@@ -14,6 +14,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <SelfContained>true</SelfContained>
     <PublishReadyToRun>false</PublishReadyToRun>
     <PublishSingleFile>true</PublishSingleFile>
-    <PublishTrimmed>false</PublishTrimmed>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 </Project>

--- a/UserControls/UserControl_ContactPersonImport.Designer.cs
+++ b/UserControls/UserControl_ContactPersonImport.Designer.cs
@@ -788,6 +788,7 @@ namespace TimeLog.DataImporter.UserControls
             // 
             // comboBox_delimiter
             // 
+            comboBox_delimiter.DropDownStyle = ComboBoxStyle.DropDownList;
             comboBox_delimiter.FormattingEnabled = true;
             comboBox_delimiter.Location = new System.Drawing.Point(82, 72);
             comboBox_delimiter.Name = "comboBox_delimiter";

--- a/UserControls/UserControl_ContractImport.Designer.cs
+++ b/UserControls/UserControl_ContractImport.Designer.cs
@@ -861,6 +861,7 @@
             // 
             // comboBox_delimiter
             // 
+            comboBox_delimiter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             comboBox_delimiter.FormattingEnabled = true;
             comboBox_delimiter.Location = new System.Drawing.Point(82, 72);
             comboBox_delimiter.Name = "comboBox_delimiter";

--- a/UserControls/UserControl_CustomerImport.Designer.cs
+++ b/UserControls/UserControl_CustomerImport.Designer.cs
@@ -30,1774 +30,1641 @@ namespace TimeLog.DataImporter.UserControls
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            this.WorkerFetcher = new System.ComponentModel.BackgroundWorker();
-            this.panel_customerDataTable = new System.Windows.Forms.Panel();
-            this.dataGridView_customer = new System.Windows.Forms.DataGridView();
-            this.panel_customerMessage = new System.Windows.Forms.Panel();
-            this.textBox_customerImportMessages = new System.Windows.Forms.TextBox();
-            this.panel_customerButtons = new System.Windows.Forms.Panel();
-            this.button_clear = new System.Windows.Forms.Button();
-            this.button_import = new System.Windows.Forms.Button();
-            this.button_validate = new System.Windows.Forms.Button();
-            this.button_stop = new System.Windows.Forms.Button();
-            this.panel_customerFieldMapping = new System.Windows.Forms.Panel();
-            this.flowLayoutPanel_NonMandatoryFields = new System.Windows.Forms.FlowLayoutPanel();
-            this.panel_customerDetailsButton = new System.Windows.Forms.Panel();
-            this.label_customerDetails = new System.Windows.Forms.Label();
-            this.button_customerDetails = new System.Windows.Forms.Button();
-            this.panel_customerDetails = new System.Windows.Forms.Panel();
-            this.label_customerNo = new System.Windows.Forms.Label();
-            this.label_nickname = new System.Windows.Forms.Label();
-            this.checkBox_defaultIndustryName = new System.Windows.Forms.CheckBox();
-            this.label_customerSince = new System.Windows.Forms.Label();
-            this.checkBox_defaultSecondaryKAM = new System.Windows.Forms.CheckBox();
-            this.label_primaryKAM = new System.Windows.Forms.Label();
-            this.comboBox_industryName = new System.Windows.Forms.ComboBox();
-            this.label_secondaryKAM = new System.Windows.Forms.Label();
-            this.comboBox_customerSince = new System.Windows.Forms.ComboBox();
-            this.label_industryName = new System.Windows.Forms.Label();
-            this.comboBox_primaryKAM = new System.Windows.Forms.ComboBox();
-            this.comboBox_secondaryKAM = new System.Windows.Forms.ComboBox();
-            this.comboBox_nickName = new System.Windows.Forms.ComboBox();
-            this.comboBox_customerNo = new System.Windows.Forms.ComboBox();
-            this.checkBox_defaultPrimaryKAM = new System.Windows.Forms.CheckBox();
-            this.panel_contactDetailsButton = new System.Windows.Forms.Panel();
-            this.label_ContactDetails = new System.Windows.Forms.Label();
-            this.button_contactDetails = new System.Windows.Forms.Button();
-            this.panel_contactDetails = new System.Windows.Forms.Panel();
-            this.label_phone = new System.Windows.Forms.Label();
-            this.label_fax = new System.Windows.Forms.Label();
-            this.label_website = new System.Windows.Forms.Label();
-            this.label_address = new System.Windows.Forms.Label();
-            this.label_address2 = new System.Windows.Forms.Label();
-            this.label_address3 = new System.Windows.Forms.Label();
-            this.label_zipCode = new System.Windows.Forms.Label();
-            this.label_city = new System.Windows.Forms.Label();
-            this.label_state = new System.Windows.Forms.Label();
-            this.label_email = new System.Windows.Forms.Label();
-            this.comboBox_phoneNo = new System.Windows.Forms.ComboBox();
-            this.comboBox_faxNo = new System.Windows.Forms.ComboBox();
-            this.comboBox_email = new System.Windows.Forms.ComboBox();
-            this.comboBox_website = new System.Windows.Forms.ComboBox();
-            this.comboBox_address = new System.Windows.Forms.ComboBox();
-            this.comboBox_address2 = new System.Windows.Forms.ComboBox();
-            this.comboBox_address3 = new System.Windows.Forms.ComboBox();
-            this.comboBox_zipCode = new System.Windows.Forms.ComboBox();
-            this.comboBox_city = new System.Windows.Forms.ComboBox();
-            this.comboBox_state = new System.Windows.Forms.ComboBox();
-            this.panel_invoiceAddressButton = new System.Windows.Forms.Panel();
-            this.label_invoiceAddress = new System.Windows.Forms.Label();
-            this.button_invoiceAddress = new System.Windows.Forms.Button();
-            this.panel_invoiceAddress = new System.Windows.Forms.Panel();
-            this.checkBox_defaultInvoicingAddressCountryISO = new System.Windows.Forms.CheckBox();
-            this.label_useInvoicingAddress = new System.Windows.Forms.Label();
-            this.label_invoicingAddress = new System.Windows.Forms.Label();
-            this.label_invoicingAddressCity = new System.Windows.Forms.Label();
-            this.label_invoicingAddressZipCode = new System.Windows.Forms.Label();
-            this.label_invoicingAddress2 = new System.Windows.Forms.Label();
-            this.label_invoicingAddress3 = new System.Windows.Forms.Label();
-            this.label_invoicingAddressState = new System.Windows.Forms.Label();
-            this.label_invoicingAddressCountryID = new System.Windows.Forms.Label();
-            this.comboBox_useInvoicingAddress = new System.Windows.Forms.ComboBox();
-            this.comboBox_invoicingAddress = new System.Windows.Forms.ComboBox();
-            this.comboBox_invoicingAddress2 = new System.Windows.Forms.ComboBox();
-            this.comboBox_invoicingAddress3 = new System.Windows.Forms.ComboBox();
-            this.comboBox_invoicingAddressZipCode = new System.Windows.Forms.ComboBox();
-            this.comboBox_invoicingAddressCity = new System.Windows.Forms.ComboBox();
-            this.comboBox_invoicingAddressState = new System.Windows.Forms.ComboBox();
-            this.comboBox_invoicingAddressCountryISO = new System.Windows.Forms.ComboBox();
-            this.panel2 = new System.Windows.Forms.Panel();
-            this.label_financeCompanyInfo = new System.Windows.Forms.Label();
-            this.button_financeCompanyInfo = new System.Windows.Forms.Button();
-            this.panel_financeCompanyInfo = new System.Windows.Forms.Panel();
-            this.label_organizationNo = new System.Windows.Forms.Label();
-            this.label_vatNo = new System.Windows.Forms.Label();
-            this.comboBox_organizationNo = new System.Windows.Forms.ComboBox();
-            this.comboBox_VATNo = new System.Windows.Forms.ComboBox();
-            this.comboBox_eanNo = new System.Windows.Forms.ComboBox();
-            this.comboBox_useEanNo = new System.Windows.Forms.ComboBox();
-            this.label_eanNo = new System.Windows.Forms.Label();
-            this.label_useEanNo = new System.Windows.Forms.Label();
-            this.panel_defaultInvoiceSettingsButton = new System.Windows.Forms.Panel();
-            this.label_defaultInvoiceSettings = new System.Windows.Forms.Label();
-            this.button_defaultInvoiceSettings = new System.Windows.Forms.Button();
-            this.panel_defaultInvoiceSettings = new System.Windows.Forms.Panel();
-            this.checkBox_defaultVATPercentage = new System.Windows.Forms.CheckBox();
-            this.checkBox_defaultPaymentTerm = new System.Windows.Forms.CheckBox();
-            this.label_paymentTerm = new System.Windows.Forms.Label();
-            this.label_discountPercentage = new System.Windows.Forms.Label();
-            this.label_calculateVAT = new System.Windows.Forms.Label();
-            this.comboBox_VATPercentage = new System.Windows.Forms.ComboBox();
-            this.label_vatPercentage = new System.Windows.Forms.Label();
-            this.comboBox_calculateVAT = new System.Windows.Forms.ComboBox();
-            this.comboBox_discountPercentage = new System.Windows.Forms.ComboBox();
-            this.comboBox_paymentTerm = new System.Windows.Forms.ComboBox();
-            this.panel_invoiceExternalCosts = new System.Windows.Forms.Panel();
-            this.label_invoiceExternalCosts = new System.Windows.Forms.Label();
-            this.button_invoiceExternalCosts = new System.Windows.Forms.Button();
-            this.panel_incoiceExternalCosts = new System.Windows.Forms.Panel();
-            this.checkBox_defaultExpenseIsBillable = new System.Windows.Forms.CheckBox();
-            this.checkBox_defaultMileageIsBillable = new System.Windows.Forms.CheckBox();
-            this.label_defaultMileageDistance = new System.Windows.Forms.Label();
-            this.label_defaultDistIsMaxBillable = new System.Windows.Forms.Label();
-            this.label_expenseIsBillable = new System.Windows.Forms.Label();
-            this.label_mileageIsBillable = new System.Windows.Forms.Label();
-            this.comboBox_defaultDistIsMaxBillable = new System.Windows.Forms.ComboBox();
-            this.comboBox_defaultMileageDistance = new System.Windows.Forms.ComboBox();
-            this.comboBox_expenseIsBillable = new System.Windows.Forms.ComboBox();
-            this.comboBox_mileageIsBillable = new System.Windows.Forms.ComboBox();
-            this.label_delimiter = new System.Windows.Forms.Label();
-            this.comboBox_delimiter = new System.Windows.Forms.ComboBox();
-            this.groupBox_customerMandatoryFields = new System.Windows.Forms.GroupBox();
-            this.checkBox_defaultCountryISO = new System.Windows.Forms.CheckBox();
-            this.checkBox_defaultCustomerStatus = new System.Windows.Forms.CheckBox();
-            this.checkBox_defaultCurrencyISO = new System.Windows.Forms.CheckBox();
-            this.label_countryISO = new System.Windows.Forms.Label();
-            this.label_customerStatus = new System.Windows.Forms.Label();
-            this.comboBox_countryISO = new System.Windows.Forms.ComboBox();
-            this.comboBox_customerStatus = new System.Windows.Forms.ComboBox();
-            this.label_currencyISO = new System.Windows.Forms.Label();
-            this.comboBox_currencyISO = new System.Windows.Forms.ComboBox();
-            this.label_customerName = new System.Windows.Forms.Label();
-            this.comboBox_customerName = new System.Windows.Forms.ComboBox();
-            this.label_customerSetup = new System.Windows.Forms.Label();
-            this.button_customerSelectFile = new System.Windows.Forms.Button();
-            this.defaultToolTip = new System.Windows.Forms.ToolTip(this.components);
-            this.tmrExpand = new System.Windows.Forms.Timer(this.components);
-            this.label1 = new System.Windows.Forms.Label();
-            this.button1 = new System.Windows.Forms.Button();
-            this.panel1 = new System.Windows.Forms.Panel();
-            this.panel_customerDataTable.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridView_customer)).BeginInit();
-            this.panel_customerMessage.SuspendLayout();
-            this.panel_customerButtons.SuspendLayout();
-            this.panel_customerFieldMapping.SuspendLayout();
-            this.flowLayoutPanel_NonMandatoryFields.SuspendLayout();
-            this.panel_customerDetailsButton.SuspendLayout();
-            this.panel_customerDetails.SuspendLayout();
-            this.panel_contactDetailsButton.SuspendLayout();
-            this.panel_contactDetails.SuspendLayout();
-            this.panel_invoiceAddressButton.SuspendLayout();
-            this.panel_invoiceAddress.SuspendLayout();
-            this.panel2.SuspendLayout();
-            this.panel_financeCompanyInfo.SuspendLayout();
-            this.panel_defaultInvoiceSettingsButton.SuspendLayout();
-            this.panel_defaultInvoiceSettings.SuspendLayout();
-            this.panel_invoiceExternalCosts.SuspendLayout();
-            this.panel_incoiceExternalCosts.SuspendLayout();
-            this.groupBox_customerMandatoryFields.SuspendLayout();
-            this.panel1.SuspendLayout();
-            this.SuspendLayout();
+            components = new System.ComponentModel.Container();
+            WorkerFetcher = new System.ComponentModel.BackgroundWorker();
+            panel_customerDataTable = new Panel();
+            dataGridView_customer = new DataGridView();
+            panel_customerMessage = new Panel();
+            textBox_customerImportMessages = new TextBox();
+            panel_customerButtons = new Panel();
+            button_clear = new Button();
+            button_import = new Button();
+            button_validate = new Button();
+            button_stop = new Button();
+            panel_customerFieldMapping = new Panel();
+            flowLayoutPanel_NonMandatoryFields = new FlowLayoutPanel();
+            panel_customerDetailsButton = new Panel();
+            label_customerDetails = new Label();
+            button_customerDetails = new Button();
+            panel_customerDetails = new Panel();
+            label_customerNo = new Label();
+            label_nickname = new Label();
+            checkBox_defaultIndustryName = new CheckBox();
+            label_customerSince = new Label();
+            checkBox_defaultSecondaryKAM = new CheckBox();
+            label_primaryKAM = new Label();
+            comboBox_industryName = new ComboBox();
+            label_secondaryKAM = new Label();
+            comboBox_customerSince = new ComboBox();
+            label_industryName = new Label();
+            comboBox_primaryKAM = new ComboBox();
+            comboBox_secondaryKAM = new ComboBox();
+            comboBox_nickName = new ComboBox();
+            comboBox_customerNo = new ComboBox();
+            checkBox_defaultPrimaryKAM = new CheckBox();
+            panel_contactDetailsButton = new Panel();
+            label_ContactDetails = new Label();
+            button_contactDetails = new Button();
+            panel_contactDetails = new Panel();
+            label_phone = new Label();
+            label_fax = new Label();
+            label_website = new Label();
+            label_address = new Label();
+            label_address2 = new Label();
+            label_address3 = new Label();
+            label_zipCode = new Label();
+            label_city = new Label();
+            label_state = new Label();
+            label_email = new Label();
+            comboBox_phoneNo = new ComboBox();
+            comboBox_faxNo = new ComboBox();
+            comboBox_email = new ComboBox();
+            comboBox_website = new ComboBox();
+            comboBox_address = new ComboBox();
+            comboBox_address2 = new ComboBox();
+            comboBox_address3 = new ComboBox();
+            comboBox_zipCode = new ComboBox();
+            comboBox_city = new ComboBox();
+            comboBox_state = new ComboBox();
+            panel_invoiceAddressButton = new Panel();
+            label_invoiceAddress = new Label();
+            button_invoiceAddress = new Button();
+            panel_invoiceAddress = new Panel();
+            checkBox_defaultInvoicingAddressCountryISO = new CheckBox();
+            label_useInvoicingAddress = new Label();
+            label_invoicingAddress = new Label();
+            label_invoicingAddressCity = new Label();
+            label_invoicingAddressZipCode = new Label();
+            label_invoicingAddress2 = new Label();
+            label_invoicingAddress3 = new Label();
+            label_invoicingAddressState = new Label();
+            label_invoicingAddressCountryID = new Label();
+            comboBox_useInvoicingAddress = new ComboBox();
+            comboBox_invoicingAddress = new ComboBox();
+            comboBox_invoicingAddress2 = new ComboBox();
+            comboBox_invoicingAddress3 = new ComboBox();
+            comboBox_invoicingAddressZipCode = new ComboBox();
+            comboBox_invoicingAddressCity = new ComboBox();
+            comboBox_invoicingAddressState = new ComboBox();
+            comboBox_invoicingAddressCountryISO = new ComboBox();
+            panel2 = new Panel();
+            label_financeCompanyInfo = new Label();
+            button_financeCompanyInfo = new Button();
+            panel_financeCompanyInfo = new Panel();
+            label_organizationNo = new Label();
+            label_vatNo = new Label();
+            comboBox_organizationNo = new ComboBox();
+            comboBox_VATNo = new ComboBox();
+            comboBox_eanNo = new ComboBox();
+            comboBox_useEanNo = new ComboBox();
+            label_eanNo = new Label();
+            label_useEanNo = new Label();
+            panel_defaultInvoiceSettingsButton = new Panel();
+            label_defaultInvoiceSettings = new Label();
+            button_defaultInvoiceSettings = new Button();
+            panel_defaultInvoiceSettings = new Panel();
+            checkBox_defaultVATPercentage = new CheckBox();
+            checkBox_defaultPaymentTerm = new CheckBox();
+            label_paymentTerm = new Label();
+            label_discountPercentage = new Label();
+            label_calculateVAT = new Label();
+            comboBox_VATPercentage = new ComboBox();
+            label_vatPercentage = new Label();
+            comboBox_calculateVAT = new ComboBox();
+            comboBox_discountPercentage = new ComboBox();
+            comboBox_paymentTerm = new ComboBox();
+            panel_invoiceExternalCosts = new Panel();
+            label_invoiceExternalCosts = new Label();
+            button_invoiceExternalCosts = new Button();
+            panel_incoiceExternalCosts = new Panel();
+            checkBox_defaultExpenseIsBillable = new CheckBox();
+            checkBox_defaultMileageIsBillable = new CheckBox();
+            label_defaultMileageDistance = new Label();
+            label_defaultDistIsMaxBillable = new Label();
+            label_expenseIsBillable = new Label();
+            label_mileageIsBillable = new Label();
+            comboBox_defaultDistIsMaxBillable = new ComboBox();
+            comboBox_defaultMileageDistance = new ComboBox();
+            comboBox_expenseIsBillable = new ComboBox();
+            comboBox_mileageIsBillable = new ComboBox();
+            label_delimiter = new Label();
+            comboBox_delimiter = new ComboBox();
+            groupBox_customerMandatoryFields = new GroupBox();
+            checkBox_defaultCountryISO = new CheckBox();
+            checkBox_defaultCustomerStatus = new CheckBox();
+            checkBox_defaultCurrencyISO = new CheckBox();
+            label_countryISO = new Label();
+            label_customerStatus = new Label();
+            comboBox_countryISO = new ComboBox();
+            comboBox_customerStatus = new ComboBox();
+            label_currencyISO = new Label();
+            comboBox_currencyISO = new ComboBox();
+            label_customerName = new Label();
+            comboBox_customerName = new ComboBox();
+            label_customerSetup = new Label();
+            button_customerSelectFile = new Button();
+            defaultToolTip = new ToolTip(components);
+            tmrExpand = new Timer(components);
+            label1 = new Label();
+            button1 = new Button();
+            panel1 = new Panel();
+            panel_customerDataTable.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)dataGridView_customer).BeginInit();
+            panel_customerMessage.SuspendLayout();
+            panel_customerButtons.SuspendLayout();
+            panel_customerFieldMapping.SuspendLayout();
+            flowLayoutPanel_NonMandatoryFields.SuspendLayout();
+            panel_customerDetailsButton.SuspendLayout();
+            panel_customerDetails.SuspendLayout();
+            panel_contactDetailsButton.SuspendLayout();
+            panel_contactDetails.SuspendLayout();
+            panel_invoiceAddressButton.SuspendLayout();
+            panel_invoiceAddress.SuspendLayout();
+            panel2.SuspendLayout();
+            panel_financeCompanyInfo.SuspendLayout();
+            panel_defaultInvoiceSettingsButton.SuspendLayout();
+            panel_defaultInvoiceSettings.SuspendLayout();
+            panel_invoiceExternalCosts.SuspendLayout();
+            panel_incoiceExternalCosts.SuspendLayout();
+            groupBox_customerMandatoryFields.SuspendLayout();
+            panel1.SuspendLayout();
+            SuspendLayout();
             // 
             // WorkerFetcher
             // 
-            this.WorkerFetcher.WorkerReportsProgress = true;
-            this.WorkerFetcher.WorkerSupportsCancellation = true;
-            this.WorkerFetcher.DoWork += new System.ComponentModel.DoWorkEventHandler(this.WorkerFetcherDoWork);
+            WorkerFetcher.WorkerReportsProgress = true;
+            WorkerFetcher.WorkerSupportsCancellation = true;
+            WorkerFetcher.DoWork += WorkerFetcherDoWork;
             // 
             // panel_customerDataTable
             // 
-            this.panel_customerDataTable.Controls.Add(this.dataGridView_customer);
-            this.panel_customerDataTable.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel_customerDataTable.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.panel_customerDataTable.Location = new System.Drawing.Point(0, 770);
-            this.panel_customerDataTable.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_customerDataTable.Name = "panel_customerDataTable";
-            this.panel_customerDataTable.Size = new System.Drawing.Size(1437, 300);
-            this.panel_customerDataTable.TabIndex = 6;
+            panel_customerDataTable.Controls.Add(dataGridView_customer);
+            panel_customerDataTable.Dock = DockStyle.Bottom;
+            panel_customerDataTable.ForeColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            panel_customerDataTable.Location = new System.Drawing.Point(0, 462);
+            panel_customerDataTable.Name = "panel_customerDataTable";
+            panel_customerDataTable.Size = new System.Drawing.Size(1006, 180);
+            panel_customerDataTable.TabIndex = 6;
             // 
             // dataGridView_customer
             // 
-            this.dataGridView_customer.BackgroundColor = System.Drawing.Color.DarkGray;
-            this.dataGridView_customer.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.dataGridView_customer.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dataGridView_customer.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.dataGridView_customer.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.dataGridView_customer.Location = new System.Drawing.Point(0, 0);
-            this.dataGridView_customer.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.dataGridView_customer.Name = "dataGridView_customer";
-            this.dataGridView_customer.RowHeadersWidth = 62;
-            this.dataGridView_customer.Size = new System.Drawing.Size(1437, 300);
-            this.dataGridView_customer.TabIndex = 0;
-            this.defaultToolTip.SetToolTip(this.dataGridView_customer, "Customer input data table");
+            dataGridView_customer.BackgroundColor = System.Drawing.Color.DarkGray;
+            dataGridView_customer.BorderStyle = BorderStyle.None;
+            dataGridView_customer.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            dataGridView_customer.Dock = DockStyle.Bottom;
+            dataGridView_customer.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold);
+            dataGridView_customer.Location = new System.Drawing.Point(0, 0);
+            dataGridView_customer.Name = "dataGridView_customer";
+            dataGridView_customer.RowHeadersWidth = 62;
+            dataGridView_customer.Size = new System.Drawing.Size(1006, 180);
+            dataGridView_customer.TabIndex = 0;
+            defaultToolTip.SetToolTip(dataGridView_customer, "Customer input data table");
             // 
             // panel_customerMessage
             // 
-            this.panel_customerMessage.Controls.Add(this.textBox_customerImportMessages);
-            this.panel_customerMessage.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel_customerMessage.Location = new System.Drawing.Point(0, 463);
-            this.panel_customerMessage.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_customerMessage.Name = "panel_customerMessage";
-            this.panel_customerMessage.Size = new System.Drawing.Size(1437, 307);
-            this.panel_customerMessage.TabIndex = 10;
+            panel_customerMessage.Controls.Add(textBox_customerImportMessages);
+            panel_customerMessage.Dock = DockStyle.Bottom;
+            panel_customerMessage.Location = new System.Drawing.Point(0, 278);
+            panel_customerMessage.Name = "panel_customerMessage";
+            panel_customerMessage.Size = new System.Drawing.Size(1006, 184);
+            panel_customerMessage.TabIndex = 10;
             // 
             // textBox_customerImportMessages
             // 
-            this.textBox_customerImportMessages.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
-            this.textBox_customerImportMessages.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.textBox_customerImportMessages.Cursor = System.Windows.Forms.Cursors.Default;
-            this.textBox_customerImportMessages.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.textBox_customerImportMessages.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.textBox_customerImportMessages.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.textBox_customerImportMessages.Location = new System.Drawing.Point(0, 0);
-            this.textBox_customerImportMessages.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.textBox_customerImportMessages.Multiline = true;
-            this.textBox_customerImportMessages.Name = "textBox_customerImportMessages";
-            this.textBox_customerImportMessages.ReadOnly = true;
-            this.textBox_customerImportMessages.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.textBox_customerImportMessages.Size = new System.Drawing.Size(1437, 307);
-            this.textBox_customerImportMessages.TabIndex = 0;
-            this.textBox_customerImportMessages.WordWrap = false;
-            this.defaultToolTip.SetToolTip(this.textBox_customerImportMessages, "Validation or import status");
-            this.textBox_customerImportMessages.MouseClick += new System.Windows.Forms.MouseEventHandler(this.textBox_customerImportMessages_MouseClick);
+            textBox_customerImportMessages.BackColor = System.Drawing.Color.FromArgb(224, 224, 224);
+            textBox_customerImportMessages.BorderStyle = BorderStyle.None;
+            textBox_customerImportMessages.Dock = DockStyle.Bottom;
+            textBox_customerImportMessages.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold);
+            textBox_customerImportMessages.ForeColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            textBox_customerImportMessages.Location = new System.Drawing.Point(0, 0);
+            textBox_customerImportMessages.Multiline = true;
+            textBox_customerImportMessages.Name = "textBox_customerImportMessages";
+            textBox_customerImportMessages.ReadOnly = true;
+            textBox_customerImportMessages.ScrollBars = ScrollBars.Vertical;
+            textBox_customerImportMessages.Size = new System.Drawing.Size(1006, 184);
+            textBox_customerImportMessages.TabIndex = 0;
+            defaultToolTip.SetToolTip(textBox_customerImportMessages, "Validation or import status");
+            textBox_customerImportMessages.WordWrap = false;
+            textBox_customerImportMessages.MouseClick += textBox_customerImportMessages_MouseClick;
             // 
             // panel_customerButtons
             // 
-            this.panel_customerButtons.Controls.Add(this.button_clear);
-            this.panel_customerButtons.Controls.Add(this.button_import);
-            this.panel_customerButtons.Controls.Add(this.button_validate);
-            this.panel_customerButtons.Controls.Add(this.button_stop);
-            this.panel_customerButtons.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel_customerButtons.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.panel_customerButtons.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.panel_customerButtons.Location = new System.Drawing.Point(0, 376);
-            this.panel_customerButtons.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_customerButtons.Name = "panel_customerButtons";
-            this.panel_customerButtons.Size = new System.Drawing.Size(1437, 87);
-            this.panel_customerButtons.TabIndex = 12;
+            panel_customerButtons.Controls.Add(button_clear);
+            panel_customerButtons.Controls.Add(button_import);
+            panel_customerButtons.Controls.Add(button_validate);
+            panel_customerButtons.Controls.Add(button_stop);
+            panel_customerButtons.Dock = DockStyle.Bottom;
+            panel_customerButtons.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold);
+            panel_customerButtons.ForeColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            panel_customerButtons.Location = new System.Drawing.Point(0, 226);
+            panel_customerButtons.Name = "panel_customerButtons";
+            panel_customerButtons.Size = new System.Drawing.Size(1006, 52);
+            panel_customerButtons.TabIndex = 12;
             // 
             // button_clear
             // 
-            this.button_clear.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.button_clear.BackColor = System.Drawing.Color.DimGray;
-            this.button_clear.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_clear.FlatAppearance.BorderSize = 0;
-            this.button_clear.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_clear.ForeColor = System.Drawing.Color.White;
-            this.button_clear.Location = new System.Drawing.Point(20, 20);
-            this.button_clear.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_clear.Name = "button_clear";
-            this.button_clear.Size = new System.Drawing.Size(114, 48);
-            this.button_clear.TabIndex = 12;
-            this.button_clear.Text = "Reset All";
-            this.defaultToolTip.SetToolTip(this.button_clear, "Reset everything and reload data from TLP");
-            this.button_clear.UseVisualStyleBackColor = false;
-            this.button_clear.Click += new System.EventHandler(this.button_clear_Click);
+            button_clear.Anchor = AnchorStyles.Left;
+            button_clear.BackColor = System.Drawing.Color.DimGray;
+            button_clear.Cursor = Cursors.Hand;
+            button_clear.FlatAppearance.BorderSize = 0;
+            button_clear.FlatStyle = FlatStyle.Flat;
+            button_clear.ForeColor = System.Drawing.Color.White;
+            button_clear.Location = new System.Drawing.Point(14, 12);
+            button_clear.Name = "button_clear";
+            button_clear.Size = new System.Drawing.Size(80, 29);
+            button_clear.TabIndex = 12;
+            button_clear.Text = "Reset All";
+            defaultToolTip.SetToolTip(button_clear, "Reset everything and reload data from TLP");
+            button_clear.UseVisualStyleBackColor = false;
+            button_clear.Click += button_clear_Click;
             // 
             // button_import
             // 
-            this.button_import.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.button_import.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(43)))), ((int)(((byte)(141)))));
-            this.button_import.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_import.FlatAppearance.BorderSize = 0;
-            this.button_import.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_import.ForeColor = System.Drawing.Color.White;
-            this.button_import.Location = new System.Drawing.Point(1310, 20);
-            this.button_import.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_import.Name = "button_import";
-            this.button_import.Size = new System.Drawing.Size(114, 48);
-            this.button_import.TabIndex = 7;
-            this.button_import.Text = "Import";
-            this.defaultToolTip.SetToolTip(this.button_import, "Import all data");
-            this.button_import.UseVisualStyleBackColor = false;
-            this.button_import.Click += new System.EventHandler(this.button_import_Click);
+            button_import.Anchor = AnchorStyles.Right;
+            button_import.BackColor = System.Drawing.Color.FromArgb(226, 43, 141);
+            button_import.Cursor = Cursors.Hand;
+            button_import.FlatAppearance.BorderSize = 0;
+            button_import.FlatStyle = FlatStyle.Flat;
+            button_import.ForeColor = System.Drawing.Color.White;
+            button_import.Location = new System.Drawing.Point(917, 12);
+            button_import.Name = "button_import";
+            button_import.Size = new System.Drawing.Size(80, 29);
+            button_import.TabIndex = 7;
+            button_import.Text = "Import";
+            defaultToolTip.SetToolTip(button_import, "Import all data");
+            button_import.UseVisualStyleBackColor = false;
+            button_import.Click += button_import_Click;
             // 
             // button_validate
             // 
-            this.button_validate.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.button_validate.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(43)))), ((int)(((byte)(141)))));
-            this.button_validate.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_validate.FlatAppearance.BorderSize = 0;
-            this.button_validate.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_validate.ForeColor = System.Drawing.Color.White;
-            this.button_validate.Location = new System.Drawing.Point(1064, 20);
-            this.button_validate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_validate.Name = "button_validate";
-            this.button_validate.Size = new System.Drawing.Size(114, 48);
-            this.button_validate.TabIndex = 8;
-            this.button_validate.Text = "Validate";
-            this.defaultToolTip.SetToolTip(this.button_validate, "Validate data input before importing data");
-            this.button_validate.UseVisualStyleBackColor = false;
-            this.button_validate.Click += new System.EventHandler(this.button_validate_Click);
+            button_validate.Anchor = AnchorStyles.Right;
+            button_validate.BackColor = System.Drawing.Color.FromArgb(226, 43, 141);
+            button_validate.Cursor = Cursors.Hand;
+            button_validate.FlatAppearance.BorderSize = 0;
+            button_validate.FlatStyle = FlatStyle.Flat;
+            button_validate.ForeColor = System.Drawing.Color.White;
+            button_validate.Location = new System.Drawing.Point(745, 12);
+            button_validate.Name = "button_validate";
+            button_validate.Size = new System.Drawing.Size(80, 29);
+            button_validate.TabIndex = 8;
+            button_validate.Text = "Validate";
+            defaultToolTip.SetToolTip(button_validate, "Validate data input before importing data");
+            button_validate.UseVisualStyleBackColor = false;
+            button_validate.Click += button_validate_Click;
             // 
             // button_stop
             // 
-            this.button_stop.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.button_stop.BackColor = System.Drawing.Color.DimGray;
-            this.button_stop.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_stop.FlatAppearance.BorderSize = 0;
-            this.button_stop.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_stop.ForeColor = System.Drawing.Color.White;
-            this.button_stop.Location = new System.Drawing.Point(1187, 20);
-            this.button_stop.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_stop.Name = "button_stop";
-            this.button_stop.Size = new System.Drawing.Size(114, 48);
-            this.button_stop.TabIndex = 11;
-            this.button_stop.Text = "Stop";
-            this.defaultToolTip.SetToolTip(this.button_stop, "Stop validation or import");
-            this.button_stop.UseVisualStyleBackColor = false;
-            this.button_stop.Click += new System.EventHandler(this.button_stop_Click);
+            button_stop.Anchor = AnchorStyles.Right;
+            button_stop.BackColor = System.Drawing.Color.DimGray;
+            button_stop.Cursor = Cursors.Hand;
+            button_stop.FlatAppearance.BorderSize = 0;
+            button_stop.FlatStyle = FlatStyle.Flat;
+            button_stop.ForeColor = System.Drawing.Color.White;
+            button_stop.Location = new System.Drawing.Point(831, 12);
+            button_stop.Name = "button_stop";
+            button_stop.Size = new System.Drawing.Size(80, 29);
+            button_stop.TabIndex = 11;
+            button_stop.Text = "Stop";
+            defaultToolTip.SetToolTip(button_stop, "Stop validation or import");
+            button_stop.UseVisualStyleBackColor = false;
+            button_stop.Click += button_stop_Click;
             // 
             // panel_customerFieldMapping
             // 
-            this.panel_customerFieldMapping.AutoScroll = true;
-            this.panel_customerFieldMapping.Controls.Add(this.flowLayoutPanel_NonMandatoryFields);
-            this.panel_customerFieldMapping.Controls.Add(this.label_delimiter);
-            this.panel_customerFieldMapping.Controls.Add(this.comboBox_delimiter);
-            this.panel_customerFieldMapping.Controls.Add(this.groupBox_customerMandatoryFields);
-            this.panel_customerFieldMapping.Controls.Add(this.label_customerSetup);
-            this.panel_customerFieldMapping.Controls.Add(this.button_customerSelectFile);
-            this.panel_customerFieldMapping.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel_customerFieldMapping.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.panel_customerFieldMapping.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.panel_customerFieldMapping.Location = new System.Drawing.Point(0, 0);
-            this.panel_customerFieldMapping.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_customerFieldMapping.Name = "panel_customerFieldMapping";
-            this.panel_customerFieldMapping.Size = new System.Drawing.Size(1437, 376);
-            this.panel_customerFieldMapping.TabIndex = 13;
+            panel_customerFieldMapping.AutoScroll = true;
+            panel_customerFieldMapping.Controls.Add(flowLayoutPanel_NonMandatoryFields);
+            panel_customerFieldMapping.Controls.Add(label_delimiter);
+            panel_customerFieldMapping.Controls.Add(comboBox_delimiter);
+            panel_customerFieldMapping.Controls.Add(groupBox_customerMandatoryFields);
+            panel_customerFieldMapping.Controls.Add(label_customerSetup);
+            panel_customerFieldMapping.Controls.Add(button_customerSelectFile);
+            panel_customerFieldMapping.Dock = DockStyle.Fill;
+            panel_customerFieldMapping.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold);
+            panel_customerFieldMapping.ForeColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            panel_customerFieldMapping.Location = new System.Drawing.Point(0, 0);
+            panel_customerFieldMapping.Name = "panel_customerFieldMapping";
+            panel_customerFieldMapping.Size = new System.Drawing.Size(1006, 226);
+            panel_customerFieldMapping.TabIndex = 13;
             // 
             // flowLayoutPanel_NonMandatoryFields
             // 
-            this.flowLayoutPanel_NonMandatoryFields.Controls.Add(this.panel_customerDetailsButton);
-            this.flowLayoutPanel_NonMandatoryFields.Controls.Add(this.panel_customerDetails);
-            this.flowLayoutPanel_NonMandatoryFields.Controls.Add(this.panel_contactDetailsButton);
-            this.flowLayoutPanel_NonMandatoryFields.Controls.Add(this.panel_contactDetails);
-            this.flowLayoutPanel_NonMandatoryFields.Controls.Add(this.panel_invoiceAddressButton);
-            this.flowLayoutPanel_NonMandatoryFields.Controls.Add(this.panel_invoiceAddress);
-            this.flowLayoutPanel_NonMandatoryFields.Controls.Add(this.panel2);
-            this.flowLayoutPanel_NonMandatoryFields.Controls.Add(this.panel_financeCompanyInfo);
-            this.flowLayoutPanel_NonMandatoryFields.Controls.Add(this.panel_defaultInvoiceSettingsButton);
-            this.flowLayoutPanel_NonMandatoryFields.Controls.Add(this.panel_defaultInvoiceSettings);
-            this.flowLayoutPanel_NonMandatoryFields.Controls.Add(this.panel_invoiceExternalCosts);
-            this.flowLayoutPanel_NonMandatoryFields.Controls.Add(this.panel_incoiceExternalCosts);
-            this.flowLayoutPanel_NonMandatoryFields.Location = new System.Drawing.Point(763, 27);
-            this.flowLayoutPanel_NonMandatoryFields.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.flowLayoutPanel_NonMandatoryFields.Name = "flowLayoutPanel_NonMandatoryFields";
-            this.flowLayoutPanel_NonMandatoryFields.Size = new System.Drawing.Size(624, 2690);
-            this.flowLayoutPanel_NonMandatoryFields.TabIndex = 8;
+            flowLayoutPanel_NonMandatoryFields.Controls.Add(panel_customerDetailsButton);
+            flowLayoutPanel_NonMandatoryFields.Controls.Add(panel_customerDetails);
+            flowLayoutPanel_NonMandatoryFields.Controls.Add(panel_contactDetailsButton);
+            flowLayoutPanel_NonMandatoryFields.Controls.Add(panel_contactDetails);
+            flowLayoutPanel_NonMandatoryFields.Controls.Add(panel_invoiceAddressButton);
+            flowLayoutPanel_NonMandatoryFields.Controls.Add(panel_invoiceAddress);
+            flowLayoutPanel_NonMandatoryFields.Controls.Add(panel2);
+            flowLayoutPanel_NonMandatoryFields.Controls.Add(panel_financeCompanyInfo);
+            flowLayoutPanel_NonMandatoryFields.Controls.Add(panel_defaultInvoiceSettingsButton);
+            flowLayoutPanel_NonMandatoryFields.Controls.Add(panel_defaultInvoiceSettings);
+            flowLayoutPanel_NonMandatoryFields.Controls.Add(panel_invoiceExternalCosts);
+            flowLayoutPanel_NonMandatoryFields.Controls.Add(panel_incoiceExternalCosts);
+            flowLayoutPanel_NonMandatoryFields.Location = new System.Drawing.Point(534, 16);
+            flowLayoutPanel_NonMandatoryFields.Name = "flowLayoutPanel_NonMandatoryFields";
+            flowLayoutPanel_NonMandatoryFields.Size = new System.Drawing.Size(437, 1614);
+            flowLayoutPanel_NonMandatoryFields.TabIndex = 8;
             // 
             // panel_customerDetailsButton
             // 
-            this.panel_customerDetailsButton.Controls.Add(this.label_customerDetails);
-            this.panel_customerDetailsButton.Controls.Add(this.button_customerDetails);
-            this.panel_customerDetailsButton.Location = new System.Drawing.Point(4, 5);
-            this.panel_customerDetailsButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_customerDetailsButton.Name = "panel_customerDetailsButton";
-            this.panel_customerDetailsButton.Size = new System.Drawing.Size(609, 53);
-            this.panel_customerDetailsButton.TabIndex = 0;
+            panel_customerDetailsButton.Controls.Add(label_customerDetails);
+            panel_customerDetailsButton.Controls.Add(button_customerDetails);
+            panel_customerDetailsButton.Location = new System.Drawing.Point(3, 3);
+            panel_customerDetailsButton.Name = "panel_customerDetailsButton";
+            panel_customerDetailsButton.Size = new System.Drawing.Size(426, 32);
+            panel_customerDetailsButton.TabIndex = 0;
             // 
             // label_customerDetails
             // 
-            this.label_customerDetails.AutoSize = true;
-            this.label_customerDetails.ForeColor = System.Drawing.Color.Black;
-            this.label_customerDetails.Location = new System.Drawing.Point(64, 13);
-            this.label_customerDetails.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_customerDetails.Name = "label_customerDetails";
-            this.label_customerDetails.Size = new System.Drawing.Size(111, 17);
-            this.label_customerDetails.TabIndex = 1;
-            this.label_customerDetails.Text = "Customer Details";
+            label_customerDetails.AutoSize = true;
+            label_customerDetails.ForeColor = System.Drawing.Color.Black;
+            label_customerDetails.Location = new System.Drawing.Point(45, 8);
+            label_customerDetails.Name = "label_customerDetails";
+            label_customerDetails.Size = new System.Drawing.Size(111, 17);
+            label_customerDetails.TabIndex = 1;
+            label_customerDetails.Text = "Customer Details";
             // 
             // button_customerDetails
             // 
-            this.button_customerDetails.BackColor = System.Drawing.Color.White;
-            this.button_customerDetails.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button_customerDetails.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_customerDetails.FlatAppearance.BorderSize = 0;
-            this.button_customerDetails.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_customerDetails.Location = new System.Drawing.Point(13, 2);
-            this.button_customerDetails.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_customerDetails.Name = "button_customerDetails";
-            this.button_customerDetails.Size = new System.Drawing.Size(43, 50);
-            this.button_customerDetails.TabIndex = 0;
-            this.button_customerDetails.UseVisualStyleBackColor = false;
-            this.button_customerDetails.Click += new System.EventHandler(this.button_expand_Click);
+            button_customerDetails.BackColor = System.Drawing.Color.White;
+            button_customerDetails.BackgroundImageLayout = ImageLayout.Stretch;
+            button_customerDetails.Cursor = Cursors.Hand;
+            button_customerDetails.FlatAppearance.BorderSize = 0;
+            button_customerDetails.FlatStyle = FlatStyle.Flat;
+            button_customerDetails.Location = new System.Drawing.Point(9, 1);
+            button_customerDetails.Name = "button_customerDetails";
+            button_customerDetails.Size = new System.Drawing.Size(30, 30);
+            button_customerDetails.TabIndex = 0;
+            button_customerDetails.UseVisualStyleBackColor = false;
+            button_customerDetails.Click += button_expand_Click;
             // 
             // panel_customerDetails
             // 
-            this.panel_customerDetails.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
-            this.panel_customerDetails.Controls.Add(this.label_customerNo);
-            this.panel_customerDetails.Controls.Add(this.label_nickname);
-            this.panel_customerDetails.Controls.Add(this.checkBox_defaultIndustryName);
-            this.panel_customerDetails.Controls.Add(this.label_customerSince);
-            this.panel_customerDetails.Controls.Add(this.checkBox_defaultSecondaryKAM);
-            this.panel_customerDetails.Controls.Add(this.label_primaryKAM);
-            this.panel_customerDetails.Controls.Add(this.comboBox_industryName);
-            this.panel_customerDetails.Controls.Add(this.label_secondaryKAM);
-            this.panel_customerDetails.Controls.Add(this.comboBox_customerSince);
-            this.panel_customerDetails.Controls.Add(this.label_industryName);
-            this.panel_customerDetails.Controls.Add(this.comboBox_primaryKAM);
-            this.panel_customerDetails.Controls.Add(this.comboBox_secondaryKAM);
-            this.panel_customerDetails.Controls.Add(this.comboBox_nickName);
-            this.panel_customerDetails.Controls.Add(this.comboBox_customerNo);
-            this.panel_customerDetails.Controls.Add(this.checkBox_defaultPrimaryKAM);
-            this.panel_customerDetails.Location = new System.Drawing.Point(4, 68);
-            this.panel_customerDetails.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_customerDetails.MaximumSize = new System.Drawing.Size(609, 338);
-            this.panel_customerDetails.MinimumSize = new System.Drawing.Size(609, 0);
-            this.panel_customerDetails.Name = "panel_customerDetails";
-            this.panel_customerDetails.Size = new System.Drawing.Size(609, 338);
-            this.panel_customerDetails.TabIndex = 10;
+            panel_customerDetails.BackColor = System.Drawing.Color.FromArgb(224, 224, 224);
+            panel_customerDetails.Controls.Add(label_customerNo);
+            panel_customerDetails.Controls.Add(label_nickname);
+            panel_customerDetails.Controls.Add(checkBox_defaultIndustryName);
+            panel_customerDetails.Controls.Add(label_customerSince);
+            panel_customerDetails.Controls.Add(checkBox_defaultSecondaryKAM);
+            panel_customerDetails.Controls.Add(label_primaryKAM);
+            panel_customerDetails.Controls.Add(comboBox_industryName);
+            panel_customerDetails.Controls.Add(label_secondaryKAM);
+            panel_customerDetails.Controls.Add(comboBox_customerSince);
+            panel_customerDetails.Controls.Add(label_industryName);
+            panel_customerDetails.Controls.Add(comboBox_primaryKAM);
+            panel_customerDetails.Controls.Add(comboBox_secondaryKAM);
+            panel_customerDetails.Controls.Add(comboBox_nickName);
+            panel_customerDetails.Controls.Add(comboBox_customerNo);
+            panel_customerDetails.Controls.Add(checkBox_defaultPrimaryKAM);
+            panel_customerDetails.Location = new System.Drawing.Point(3, 41);
+            panel_customerDetails.MaximumSize = new System.Drawing.Size(426, 203);
+            panel_customerDetails.MinimumSize = new System.Drawing.Size(426, 0);
+            panel_customerDetails.Name = "panel_customerDetails";
+            panel_customerDetails.Size = new System.Drawing.Size(426, 203);
+            panel_customerDetails.TabIndex = 10;
             // 
             // label_customerNo
             // 
-            this.label_customerNo.AutoSize = true;
-            this.label_customerNo.Location = new System.Drawing.Point(14, 25);
-            this.label_customerNo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_customerNo.Name = "label_customerNo";
-            this.label_customerNo.Size = new System.Drawing.Size(89, 17);
-            this.label_customerNo.TabIndex = 1;
-            this.label_customerNo.Text = "Customer No";
+            label_customerNo.AutoSize = true;
+            label_customerNo.Location = new System.Drawing.Point(10, 15);
+            label_customerNo.Name = "label_customerNo";
+            label_customerNo.Size = new System.Drawing.Size(89, 17);
+            label_customerNo.TabIndex = 1;
+            label_customerNo.Text = "Customer No";
             // 
             // label_nickname
             // 
-            this.label_nickname.AutoSize = true;
-            this.label_nickname.Location = new System.Drawing.Point(14, 77);
-            this.label_nickname.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_nickname.Name = "label_nickname";
-            this.label_nickname.Size = new System.Drawing.Size(68, 17);
-            this.label_nickname.TabIndex = 1;
-            this.label_nickname.Text = "Nickname";
+            label_nickname.AutoSize = true;
+            label_nickname.Location = new System.Drawing.Point(10, 46);
+            label_nickname.Name = "label_nickname";
+            label_nickname.Size = new System.Drawing.Size(68, 17);
+            label_nickname.TabIndex = 1;
+            label_nickname.Text = "Nickname";
             // 
             // checkBox_defaultIndustryName
             // 
-            this.checkBox_defaultIndustryName.AutoSize = true;
-            this.checkBox_defaultIndustryName.Location = new System.Drawing.Point(424, 282);
-            this.checkBox_defaultIndustryName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultIndustryName.Name = "checkBox_defaultIndustryName";
-            this.checkBox_defaultIndustryName.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultIndustryName.TabIndex = 8;
-            this.checkBox_defaultIndustryName.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultIndustryName, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultIndustryName.UseVisualStyleBackColor = true;
-            this.checkBox_defaultIndustryName.CheckedChanged += new System.EventHandler(this.checkBox_defaultIndustryName_CheckedChanged);
+            checkBox_defaultIndustryName.AutoSize = true;
+            checkBox_defaultIndustryName.Location = new System.Drawing.Point(297, 169);
+            checkBox_defaultIndustryName.Name = "checkBox_defaultIndustryName";
+            checkBox_defaultIndustryName.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultIndustryName.TabIndex = 8;
+            checkBox_defaultIndustryName.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultIndustryName, "Set default values for all rows of a particular column field");
+            checkBox_defaultIndustryName.UseVisualStyleBackColor = true;
+            checkBox_defaultIndustryName.CheckedChanged += checkBox_defaultIndustryName_CheckedChanged;
             // 
             // label_customerSince
             // 
-            this.label_customerSince.AutoSize = true;
-            this.label_customerSince.Location = new System.Drawing.Point(14, 232);
-            this.label_customerSince.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_customerSince.Name = "label_customerSince";
-            this.label_customerSince.Size = new System.Drawing.Size(102, 17);
-            this.label_customerSince.TabIndex = 1;
-            this.label_customerSince.Text = "Customer Since";
+            label_customerSince.AutoSize = true;
+            label_customerSince.Location = new System.Drawing.Point(10, 139);
+            label_customerSince.Name = "label_customerSince";
+            label_customerSince.Size = new System.Drawing.Size(102, 17);
+            label_customerSince.TabIndex = 1;
+            label_customerSince.Text = "Customer Since";
             // 
             // checkBox_defaultSecondaryKAM
             // 
-            this.checkBox_defaultSecondaryKAM.AutoSize = true;
-            this.checkBox_defaultSecondaryKAM.Location = new System.Drawing.Point(424, 178);
-            this.checkBox_defaultSecondaryKAM.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultSecondaryKAM.Name = "checkBox_defaultSecondaryKAM";
-            this.checkBox_defaultSecondaryKAM.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultSecondaryKAM.TabIndex = 8;
-            this.checkBox_defaultSecondaryKAM.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultSecondaryKAM, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultSecondaryKAM.UseVisualStyleBackColor = true;
-            this.checkBox_defaultSecondaryKAM.CheckedChanged += new System.EventHandler(this.checkBox_defaultSecondaryKAM_CheckedChanged);
+            checkBox_defaultSecondaryKAM.AutoSize = true;
+            checkBox_defaultSecondaryKAM.Location = new System.Drawing.Point(297, 107);
+            checkBox_defaultSecondaryKAM.Name = "checkBox_defaultSecondaryKAM";
+            checkBox_defaultSecondaryKAM.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultSecondaryKAM.TabIndex = 8;
+            checkBox_defaultSecondaryKAM.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultSecondaryKAM, "Set default values for all rows of a particular column field");
+            checkBox_defaultSecondaryKAM.UseVisualStyleBackColor = true;
+            checkBox_defaultSecondaryKAM.CheckedChanged += checkBox_defaultSecondaryKAM_CheckedChanged;
             // 
             // label_primaryKAM
             // 
-            this.label_primaryKAM.AutoSize = true;
-            this.label_primaryKAM.Location = new System.Drawing.Point(14, 128);
-            this.label_primaryKAM.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_primaryKAM.Name = "label_primaryKAM";
-            this.label_primaryKAM.Size = new System.Drawing.Size(89, 17);
-            this.label_primaryKAM.TabIndex = 1;
-            this.label_primaryKAM.Text = "Primary KAM";
+            label_primaryKAM.AutoSize = true;
+            label_primaryKAM.Location = new System.Drawing.Point(10, 77);
+            label_primaryKAM.Name = "label_primaryKAM";
+            label_primaryKAM.Size = new System.Drawing.Size(89, 17);
+            label_primaryKAM.TabIndex = 1;
+            label_primaryKAM.Text = "Primary KAM";
             // 
             // comboBox_industryName
             // 
-            this.comboBox_industryName.FormattingEnabled = true;
-            this.comboBox_industryName.Location = new System.Drawing.Point(219, 278);
-            this.comboBox_industryName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_industryName.Name = "comboBox_industryName";
-            this.comboBox_industryName.Size = new System.Drawing.Size(195, 25);
-            this.comboBox_industryName.TabIndex = 3;
+            comboBox_industryName.FormattingEnabled = true;
+            comboBox_industryName.Location = new System.Drawing.Point(153, 167);
+            comboBox_industryName.Name = "comboBox_industryName";
+            comboBox_industryName.Size = new System.Drawing.Size(138, 25);
+            comboBox_industryName.TabIndex = 3;
             // 
             // label_secondaryKAM
             // 
-            this.label_secondaryKAM.AutoSize = true;
-            this.label_secondaryKAM.Location = new System.Drawing.Point(14, 180);
-            this.label_secondaryKAM.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_secondaryKAM.Name = "label_secondaryKAM";
-            this.label_secondaryKAM.Size = new System.Drawing.Size(105, 17);
-            this.label_secondaryKAM.TabIndex = 1;
-            this.label_secondaryKAM.Text = "Secondary KAM";
+            label_secondaryKAM.AutoSize = true;
+            label_secondaryKAM.Location = new System.Drawing.Point(10, 108);
+            label_secondaryKAM.Name = "label_secondaryKAM";
+            label_secondaryKAM.Size = new System.Drawing.Size(105, 17);
+            label_secondaryKAM.TabIndex = 1;
+            label_secondaryKAM.Text = "Secondary KAM";
             // 
             // comboBox_customerSince
             // 
-            this.comboBox_customerSince.FormattingEnabled = true;
-            this.comboBox_customerSince.Location = new System.Drawing.Point(219, 227);
-            this.comboBox_customerSince.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_customerSince.Name = "comboBox_customerSince";
-            this.comboBox_customerSince.Size = new System.Drawing.Size(195, 25);
-            this.comboBox_customerSince.TabIndex = 3;
+            comboBox_customerSince.FormattingEnabled = true;
+            comboBox_customerSince.Location = new System.Drawing.Point(153, 136);
+            comboBox_customerSince.Name = "comboBox_customerSince";
+            comboBox_customerSince.Size = new System.Drawing.Size(138, 25);
+            comboBox_customerSince.TabIndex = 3;
             // 
             // label_industryName
             // 
-            this.label_industryName.AutoSize = true;
-            this.label_industryName.Location = new System.Drawing.Point(14, 283);
-            this.label_industryName.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_industryName.Name = "label_industryName";
-            this.label_industryName.Size = new System.Drawing.Size(100, 17);
-            this.label_industryName.TabIndex = 1;
-            this.label_industryName.Text = "Industry Name";
+            label_industryName.AutoSize = true;
+            label_industryName.Location = new System.Drawing.Point(10, 170);
+            label_industryName.Name = "label_industryName";
+            label_industryName.Size = new System.Drawing.Size(100, 17);
+            label_industryName.TabIndex = 1;
+            label_industryName.Text = "Industry Name";
             // 
             // comboBox_primaryKAM
             // 
-            this.comboBox_primaryKAM.FormattingEnabled = true;
-            this.comboBox_primaryKAM.Location = new System.Drawing.Point(219, 123);
-            this.comboBox_primaryKAM.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_primaryKAM.Name = "comboBox_primaryKAM";
-            this.comboBox_primaryKAM.Size = new System.Drawing.Size(195, 25);
-            this.comboBox_primaryKAM.TabIndex = 3;
+            comboBox_primaryKAM.FormattingEnabled = true;
+            comboBox_primaryKAM.Location = new System.Drawing.Point(153, 74);
+            comboBox_primaryKAM.Name = "comboBox_primaryKAM";
+            comboBox_primaryKAM.Size = new System.Drawing.Size(138, 25);
+            comboBox_primaryKAM.TabIndex = 3;
             // 
             // comboBox_secondaryKAM
             // 
-            this.comboBox_secondaryKAM.FormattingEnabled = true;
-            this.comboBox_secondaryKAM.Location = new System.Drawing.Point(219, 175);
-            this.comboBox_secondaryKAM.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_secondaryKAM.Name = "comboBox_secondaryKAM";
-            this.comboBox_secondaryKAM.Size = new System.Drawing.Size(195, 25);
-            this.comboBox_secondaryKAM.TabIndex = 3;
+            comboBox_secondaryKAM.FormattingEnabled = true;
+            comboBox_secondaryKAM.Location = new System.Drawing.Point(153, 105);
+            comboBox_secondaryKAM.Name = "comboBox_secondaryKAM";
+            comboBox_secondaryKAM.Size = new System.Drawing.Size(138, 25);
+            comboBox_secondaryKAM.TabIndex = 3;
             // 
             // comboBox_nickName
             // 
-            this.comboBox_nickName.FormattingEnabled = true;
-            this.comboBox_nickName.Location = new System.Drawing.Point(219, 72);
-            this.comboBox_nickName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_nickName.Name = "comboBox_nickName";
-            this.comboBox_nickName.Size = new System.Drawing.Size(195, 25);
-            this.comboBox_nickName.TabIndex = 3;
+            comboBox_nickName.FormattingEnabled = true;
+            comboBox_nickName.Location = new System.Drawing.Point(153, 43);
+            comboBox_nickName.Name = "comboBox_nickName";
+            comboBox_nickName.Size = new System.Drawing.Size(138, 25);
+            comboBox_nickName.TabIndex = 3;
             // 
             // comboBox_customerNo
             // 
-            this.comboBox_customerNo.FormattingEnabled = true;
-            this.comboBox_customerNo.Location = new System.Drawing.Point(219, 20);
-            this.comboBox_customerNo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_customerNo.Name = "comboBox_customerNo";
-            this.comboBox_customerNo.Size = new System.Drawing.Size(195, 25);
-            this.comboBox_customerNo.TabIndex = 3;
+            comboBox_customerNo.FormattingEnabled = true;
+            comboBox_customerNo.Location = new System.Drawing.Point(153, 12);
+            comboBox_customerNo.Name = "comboBox_customerNo";
+            comboBox_customerNo.Size = new System.Drawing.Size(138, 25);
+            comboBox_customerNo.TabIndex = 3;
             // 
             // checkBox_defaultPrimaryKAM
             // 
-            this.checkBox_defaultPrimaryKAM.AutoSize = true;
-            this.checkBox_defaultPrimaryKAM.Location = new System.Drawing.Point(424, 127);
-            this.checkBox_defaultPrimaryKAM.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultPrimaryKAM.Name = "checkBox_defaultPrimaryKAM";
-            this.checkBox_defaultPrimaryKAM.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultPrimaryKAM.TabIndex = 8;
-            this.checkBox_defaultPrimaryKAM.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultPrimaryKAM, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultPrimaryKAM.UseVisualStyleBackColor = true;
-            this.checkBox_defaultPrimaryKAM.CheckedChanged += new System.EventHandler(this.checkBox_defaultPrimaryKAM_CheckedChanged);
+            checkBox_defaultPrimaryKAM.AutoSize = true;
+            checkBox_defaultPrimaryKAM.Location = new System.Drawing.Point(297, 76);
+            checkBox_defaultPrimaryKAM.Name = "checkBox_defaultPrimaryKAM";
+            checkBox_defaultPrimaryKAM.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultPrimaryKAM.TabIndex = 8;
+            checkBox_defaultPrimaryKAM.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultPrimaryKAM, "Set default values for all rows of a particular column field");
+            checkBox_defaultPrimaryKAM.UseVisualStyleBackColor = true;
+            checkBox_defaultPrimaryKAM.CheckedChanged += checkBox_defaultPrimaryKAM_CheckedChanged;
             // 
             // panel_contactDetailsButton
             // 
-            this.panel_contactDetailsButton.Controls.Add(this.label_ContactDetails);
-            this.panel_contactDetailsButton.Controls.Add(this.button_contactDetails);
-            this.panel_contactDetailsButton.Location = new System.Drawing.Point(4, 416);
-            this.panel_contactDetailsButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_contactDetailsButton.Name = "panel_contactDetailsButton";
-            this.panel_contactDetailsButton.Size = new System.Drawing.Size(609, 53);
-            this.panel_contactDetailsButton.TabIndex = 11;
+            panel_contactDetailsButton.Controls.Add(label_ContactDetails);
+            panel_contactDetailsButton.Controls.Add(button_contactDetails);
+            panel_contactDetailsButton.Location = new System.Drawing.Point(3, 250);
+            panel_contactDetailsButton.Name = "panel_contactDetailsButton";
+            panel_contactDetailsButton.Size = new System.Drawing.Size(426, 32);
+            panel_contactDetailsButton.TabIndex = 11;
             // 
             // label_ContactDetails
             // 
-            this.label_ContactDetails.AutoSize = true;
-            this.label_ContactDetails.ForeColor = System.Drawing.Color.Black;
-            this.label_ContactDetails.Location = new System.Drawing.Point(64, 13);
-            this.label_ContactDetails.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_ContactDetails.Name = "label_ContactDetails";
-            this.label_ContactDetails.Size = new System.Drawing.Size(99, 17);
-            this.label_ContactDetails.TabIndex = 1;
-            this.label_ContactDetails.Text = "Contact Details";
+            label_ContactDetails.AutoSize = true;
+            label_ContactDetails.ForeColor = System.Drawing.Color.Black;
+            label_ContactDetails.Location = new System.Drawing.Point(45, 8);
+            label_ContactDetails.Name = "label_ContactDetails";
+            label_ContactDetails.Size = new System.Drawing.Size(99, 17);
+            label_ContactDetails.TabIndex = 1;
+            label_ContactDetails.Text = "Contact Details";
             // 
             // button_contactDetails
             // 
-            this.button_contactDetails.BackColor = System.Drawing.Color.White;
-            this.button_contactDetails.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button_contactDetails.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_contactDetails.FlatAppearance.BorderSize = 0;
-            this.button_contactDetails.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_contactDetails.Location = new System.Drawing.Point(13, 2);
-            this.button_contactDetails.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_contactDetails.Name = "button_contactDetails";
-            this.button_contactDetails.Size = new System.Drawing.Size(43, 50);
-            this.button_contactDetails.TabIndex = 0;
-            this.button_contactDetails.UseVisualStyleBackColor = false;
-            this.button_contactDetails.Click += new System.EventHandler(this.button_expand_Click);
+            button_contactDetails.BackColor = System.Drawing.Color.White;
+            button_contactDetails.BackgroundImageLayout = ImageLayout.Stretch;
+            button_contactDetails.Cursor = Cursors.Hand;
+            button_contactDetails.FlatAppearance.BorderSize = 0;
+            button_contactDetails.FlatStyle = FlatStyle.Flat;
+            button_contactDetails.Location = new System.Drawing.Point(9, 1);
+            button_contactDetails.Name = "button_contactDetails";
+            button_contactDetails.Size = new System.Drawing.Size(30, 30);
+            button_contactDetails.TabIndex = 0;
+            button_contactDetails.UseVisualStyleBackColor = false;
+            button_contactDetails.Click += button_expand_Click;
             // 
             // panel_contactDetails
             // 
-            this.panel_contactDetails.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
-            this.panel_contactDetails.Controls.Add(this.label_phone);
-            this.panel_contactDetails.Controls.Add(this.label_fax);
-            this.panel_contactDetails.Controls.Add(this.label_website);
-            this.panel_contactDetails.Controls.Add(this.label_address);
-            this.panel_contactDetails.Controls.Add(this.label_address2);
-            this.panel_contactDetails.Controls.Add(this.label_address3);
-            this.panel_contactDetails.Controls.Add(this.label_zipCode);
-            this.panel_contactDetails.Controls.Add(this.label_city);
-            this.panel_contactDetails.Controls.Add(this.label_state);
-            this.panel_contactDetails.Controls.Add(this.label_email);
-            this.panel_contactDetails.Controls.Add(this.comboBox_phoneNo);
-            this.panel_contactDetails.Controls.Add(this.comboBox_faxNo);
-            this.panel_contactDetails.Controls.Add(this.comboBox_email);
-            this.panel_contactDetails.Controls.Add(this.comboBox_website);
-            this.panel_contactDetails.Controls.Add(this.comboBox_address);
-            this.panel_contactDetails.Controls.Add(this.comboBox_address2);
-            this.panel_contactDetails.Controls.Add(this.comboBox_address3);
-            this.panel_contactDetails.Controls.Add(this.comboBox_zipCode);
-            this.panel_contactDetails.Controls.Add(this.comboBox_city);
-            this.panel_contactDetails.Controls.Add(this.comboBox_state);
-            this.panel_contactDetails.Location = new System.Drawing.Point(4, 479);
-            this.panel_contactDetails.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_contactDetails.MaximumSize = new System.Drawing.Size(609, 545);
-            this.panel_contactDetails.MinimumSize = new System.Drawing.Size(609, 0);
-            this.panel_contactDetails.Name = "panel_contactDetails";
-            this.panel_contactDetails.Size = new System.Drawing.Size(609, 545);
-            this.panel_contactDetails.TabIndex = 1;
+            panel_contactDetails.BackColor = System.Drawing.Color.FromArgb(224, 224, 224);
+            panel_contactDetails.Controls.Add(label_phone);
+            panel_contactDetails.Controls.Add(label_fax);
+            panel_contactDetails.Controls.Add(label_website);
+            panel_contactDetails.Controls.Add(label_address);
+            panel_contactDetails.Controls.Add(label_address2);
+            panel_contactDetails.Controls.Add(label_address3);
+            panel_contactDetails.Controls.Add(label_zipCode);
+            panel_contactDetails.Controls.Add(label_city);
+            panel_contactDetails.Controls.Add(label_state);
+            panel_contactDetails.Controls.Add(label_email);
+            panel_contactDetails.Controls.Add(comboBox_phoneNo);
+            panel_contactDetails.Controls.Add(comboBox_faxNo);
+            panel_contactDetails.Controls.Add(comboBox_email);
+            panel_contactDetails.Controls.Add(comboBox_website);
+            panel_contactDetails.Controls.Add(comboBox_address);
+            panel_contactDetails.Controls.Add(comboBox_address2);
+            panel_contactDetails.Controls.Add(comboBox_address3);
+            panel_contactDetails.Controls.Add(comboBox_zipCode);
+            panel_contactDetails.Controls.Add(comboBox_city);
+            panel_contactDetails.Controls.Add(comboBox_state);
+            panel_contactDetails.Location = new System.Drawing.Point(3, 288);
+            panel_contactDetails.MaximumSize = new System.Drawing.Size(426, 327);
+            panel_contactDetails.MinimumSize = new System.Drawing.Size(426, 0);
+            panel_contactDetails.Name = "panel_contactDetails";
+            panel_contactDetails.Size = new System.Drawing.Size(426, 327);
+            panel_contactDetails.TabIndex = 1;
             // 
             // label_phone
             // 
-            this.label_phone.AutoSize = true;
-            this.label_phone.Location = new System.Drawing.Point(14, 25);
-            this.label_phone.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_phone.Name = "label_phone";
-            this.label_phone.Size = new System.Drawing.Size(69, 17);
-            this.label_phone.TabIndex = 1;
-            this.label_phone.Text = "Phone No";
+            label_phone.AutoSize = true;
+            label_phone.Location = new System.Drawing.Point(10, 15);
+            label_phone.Name = "label_phone";
+            label_phone.Size = new System.Drawing.Size(69, 17);
+            label_phone.TabIndex = 1;
+            label_phone.Text = "Phone No";
             // 
             // label_fax
             // 
-            this.label_fax.AutoSize = true;
-            this.label_fax.Location = new System.Drawing.Point(14, 77);
-            this.label_fax.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_fax.Name = "label_fax";
-            this.label_fax.Size = new System.Drawing.Size(51, 17);
-            this.label_fax.TabIndex = 1;
-            this.label_fax.Text = "Fax No";
+            label_fax.AutoSize = true;
+            label_fax.Location = new System.Drawing.Point(10, 46);
+            label_fax.Name = "label_fax";
+            label_fax.Size = new System.Drawing.Size(51, 17);
+            label_fax.TabIndex = 1;
+            label_fax.Text = "Fax No";
             // 
             // label_website
             // 
-            this.label_website.AutoSize = true;
-            this.label_website.Location = new System.Drawing.Point(14, 180);
-            this.label_website.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_website.Name = "label_website";
-            this.label_website.Size = new System.Drawing.Size(57, 17);
-            this.label_website.TabIndex = 1;
-            this.label_website.Text = "Website";
+            label_website.AutoSize = true;
+            label_website.Location = new System.Drawing.Point(10, 108);
+            label_website.Name = "label_website";
+            label_website.Size = new System.Drawing.Size(57, 17);
+            label_website.TabIndex = 1;
+            label_website.Text = "Website";
             // 
             // label_address
             // 
-            this.label_address.AutoSize = true;
-            this.label_address.Location = new System.Drawing.Point(14, 232);
-            this.label_address.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_address.Name = "label_address";
-            this.label_address.Size = new System.Drawing.Size(57, 17);
-            this.label_address.TabIndex = 1;
-            this.label_address.Text = "Address";
+            label_address.AutoSize = true;
+            label_address.Location = new System.Drawing.Point(10, 139);
+            label_address.Name = "label_address";
+            label_address.Size = new System.Drawing.Size(57, 17);
+            label_address.TabIndex = 1;
+            label_address.Text = "Address";
             // 
             // label_address2
             // 
-            this.label_address2.AutoSize = true;
-            this.label_address2.Location = new System.Drawing.Point(14, 283);
-            this.label_address2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_address2.Name = "label_address2";
-            this.label_address2.Size = new System.Drawing.Size(68, 17);
-            this.label_address2.TabIndex = 1;
-            this.label_address2.Text = "Address 2";
+            label_address2.AutoSize = true;
+            label_address2.Location = new System.Drawing.Point(10, 170);
+            label_address2.Name = "label_address2";
+            label_address2.Size = new System.Drawing.Size(68, 17);
+            label_address2.TabIndex = 1;
+            label_address2.Text = "Address 2";
             // 
             // label_address3
             // 
-            this.label_address3.AutoSize = true;
-            this.label_address3.Location = new System.Drawing.Point(14, 335);
-            this.label_address3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_address3.Name = "label_address3";
-            this.label_address3.Size = new System.Drawing.Size(68, 17);
-            this.label_address3.TabIndex = 1;
-            this.label_address3.Text = "Address 3";
+            label_address3.AutoSize = true;
+            label_address3.Location = new System.Drawing.Point(10, 201);
+            label_address3.Name = "label_address3";
+            label_address3.Size = new System.Drawing.Size(68, 17);
+            label_address3.TabIndex = 1;
+            label_address3.Text = "Address 3";
             // 
             // label_zipCode
             // 
-            this.label_zipCode.AutoSize = true;
-            this.label_zipCode.Location = new System.Drawing.Point(14, 387);
-            this.label_zipCode.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_zipCode.Name = "label_zipCode";
-            this.label_zipCode.Size = new System.Drawing.Size(62, 17);
-            this.label_zipCode.TabIndex = 1;
-            this.label_zipCode.Text = "Zip Code";
+            label_zipCode.AutoSize = true;
+            label_zipCode.Location = new System.Drawing.Point(10, 232);
+            label_zipCode.Name = "label_zipCode";
+            label_zipCode.Size = new System.Drawing.Size(62, 17);
+            label_zipCode.TabIndex = 1;
+            label_zipCode.Text = "Zip Code";
             // 
             // label_city
             // 
-            this.label_city.AutoSize = true;
-            this.label_city.Location = new System.Drawing.Point(14, 438);
-            this.label_city.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_city.Name = "label_city";
-            this.label_city.Size = new System.Drawing.Size(31, 17);
-            this.label_city.TabIndex = 1;
-            this.label_city.Text = "City";
+            label_city.AutoSize = true;
+            label_city.Location = new System.Drawing.Point(10, 263);
+            label_city.Name = "label_city";
+            label_city.Size = new System.Drawing.Size(31, 17);
+            label_city.TabIndex = 1;
+            label_city.Text = "City";
             // 
             // label_state
             // 
-            this.label_state.AutoSize = true;
-            this.label_state.Location = new System.Drawing.Point(14, 490);
-            this.label_state.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_state.Name = "label_state";
-            this.label_state.Size = new System.Drawing.Size(39, 17);
-            this.label_state.TabIndex = 1;
-            this.label_state.Text = "State";
+            label_state.AutoSize = true;
+            label_state.Location = new System.Drawing.Point(10, 294);
+            label_state.Name = "label_state";
+            label_state.Size = new System.Drawing.Size(39, 17);
+            label_state.TabIndex = 1;
+            label_state.Text = "State";
             // 
             // label_email
             // 
-            this.label_email.AutoSize = true;
-            this.label_email.Location = new System.Drawing.Point(14, 128);
-            this.label_email.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_email.Name = "label_email";
-            this.label_email.Size = new System.Drawing.Size(40, 17);
-            this.label_email.TabIndex = 1;
-            this.label_email.Text = "Email";
+            label_email.AutoSize = true;
+            label_email.Location = new System.Drawing.Point(10, 77);
+            label_email.Name = "label_email";
+            label_email.Size = new System.Drawing.Size(40, 17);
+            label_email.TabIndex = 1;
+            label_email.Text = "Email";
             // 
             // comboBox_phoneNo
             // 
-            this.comboBox_phoneNo.FormattingEnabled = true;
-            this.comboBox_phoneNo.Location = new System.Drawing.Point(171, 20);
-            this.comboBox_phoneNo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_phoneNo.Name = "comboBox_phoneNo";
-            this.comboBox_phoneNo.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_phoneNo.TabIndex = 3;
+            comboBox_phoneNo.FormattingEnabled = true;
+            comboBox_phoneNo.Location = new System.Drawing.Point(120, 12);
+            comboBox_phoneNo.Name = "comboBox_phoneNo";
+            comboBox_phoneNo.Size = new System.Drawing.Size(133, 25);
+            comboBox_phoneNo.TabIndex = 3;
             // 
             // comboBox_faxNo
             // 
-            this.comboBox_faxNo.FormattingEnabled = true;
-            this.comboBox_faxNo.Location = new System.Drawing.Point(171, 72);
-            this.comboBox_faxNo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_faxNo.Name = "comboBox_faxNo";
-            this.comboBox_faxNo.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_faxNo.TabIndex = 3;
+            comboBox_faxNo.FormattingEnabled = true;
+            comboBox_faxNo.Location = new System.Drawing.Point(120, 43);
+            comboBox_faxNo.Name = "comboBox_faxNo";
+            comboBox_faxNo.Size = new System.Drawing.Size(133, 25);
+            comboBox_faxNo.TabIndex = 3;
             // 
             // comboBox_email
             // 
-            this.comboBox_email.FormattingEnabled = true;
-            this.comboBox_email.Location = new System.Drawing.Point(171, 123);
-            this.comboBox_email.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_email.Name = "comboBox_email";
-            this.comboBox_email.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_email.TabIndex = 3;
+            comboBox_email.FormattingEnabled = true;
+            comboBox_email.Location = new System.Drawing.Point(120, 74);
+            comboBox_email.Name = "comboBox_email";
+            comboBox_email.Size = new System.Drawing.Size(133, 25);
+            comboBox_email.TabIndex = 3;
             // 
             // comboBox_website
             // 
-            this.comboBox_website.FormattingEnabled = true;
-            this.comboBox_website.Location = new System.Drawing.Point(171, 175);
-            this.comboBox_website.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_website.Name = "comboBox_website";
-            this.comboBox_website.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_website.TabIndex = 3;
+            comboBox_website.FormattingEnabled = true;
+            comboBox_website.Location = new System.Drawing.Point(120, 105);
+            comboBox_website.Name = "comboBox_website";
+            comboBox_website.Size = new System.Drawing.Size(133, 25);
+            comboBox_website.TabIndex = 3;
             // 
             // comboBox_address
             // 
-            this.comboBox_address.FormattingEnabled = true;
-            this.comboBox_address.Location = new System.Drawing.Point(171, 227);
-            this.comboBox_address.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_address.Name = "comboBox_address";
-            this.comboBox_address.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_address.TabIndex = 3;
+            comboBox_address.FormattingEnabled = true;
+            comboBox_address.Location = new System.Drawing.Point(120, 136);
+            comboBox_address.Name = "comboBox_address";
+            comboBox_address.Size = new System.Drawing.Size(133, 25);
+            comboBox_address.TabIndex = 3;
             // 
             // comboBox_address2
             // 
-            this.comboBox_address2.FormattingEnabled = true;
-            this.comboBox_address2.Location = new System.Drawing.Point(171, 278);
-            this.comboBox_address2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_address2.Name = "comboBox_address2";
-            this.comboBox_address2.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_address2.TabIndex = 3;
+            comboBox_address2.FormattingEnabled = true;
+            comboBox_address2.Location = new System.Drawing.Point(120, 167);
+            comboBox_address2.Name = "comboBox_address2";
+            comboBox_address2.Size = new System.Drawing.Size(133, 25);
+            comboBox_address2.TabIndex = 3;
             // 
             // comboBox_address3
             // 
-            this.comboBox_address3.FormattingEnabled = true;
-            this.comboBox_address3.Location = new System.Drawing.Point(171, 330);
-            this.comboBox_address3.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_address3.Name = "comboBox_address3";
-            this.comboBox_address3.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_address3.TabIndex = 3;
+            comboBox_address3.FormattingEnabled = true;
+            comboBox_address3.Location = new System.Drawing.Point(120, 198);
+            comboBox_address3.Name = "comboBox_address3";
+            comboBox_address3.Size = new System.Drawing.Size(133, 25);
+            comboBox_address3.TabIndex = 3;
             // 
             // comboBox_zipCode
             // 
-            this.comboBox_zipCode.FormattingEnabled = true;
-            this.comboBox_zipCode.Location = new System.Drawing.Point(171, 382);
-            this.comboBox_zipCode.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_zipCode.Name = "comboBox_zipCode";
-            this.comboBox_zipCode.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_zipCode.TabIndex = 3;
+            comboBox_zipCode.FormattingEnabled = true;
+            comboBox_zipCode.Location = new System.Drawing.Point(120, 229);
+            comboBox_zipCode.Name = "comboBox_zipCode";
+            comboBox_zipCode.Size = new System.Drawing.Size(133, 25);
+            comboBox_zipCode.TabIndex = 3;
             // 
             // comboBox_city
             // 
-            this.comboBox_city.FormattingEnabled = true;
-            this.comboBox_city.Location = new System.Drawing.Point(171, 433);
-            this.comboBox_city.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_city.Name = "comboBox_city";
-            this.comboBox_city.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_city.TabIndex = 3;
+            comboBox_city.FormattingEnabled = true;
+            comboBox_city.Location = new System.Drawing.Point(120, 260);
+            comboBox_city.Name = "comboBox_city";
+            comboBox_city.Size = new System.Drawing.Size(133, 25);
+            comboBox_city.TabIndex = 3;
             // 
             // comboBox_state
             // 
-            this.comboBox_state.FormattingEnabled = true;
-            this.comboBox_state.Location = new System.Drawing.Point(171, 485);
-            this.comboBox_state.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_state.Name = "comboBox_state";
-            this.comboBox_state.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_state.TabIndex = 3;
+            comboBox_state.FormattingEnabled = true;
+            comboBox_state.Location = new System.Drawing.Point(120, 291);
+            comboBox_state.Name = "comboBox_state";
+            comboBox_state.Size = new System.Drawing.Size(133, 25);
+            comboBox_state.TabIndex = 3;
             // 
             // panel_invoiceAddressButton
             // 
-            this.panel_invoiceAddressButton.Controls.Add(this.label_invoiceAddress);
-            this.panel_invoiceAddressButton.Controls.Add(this.button_invoiceAddress);
-            this.panel_invoiceAddressButton.Location = new System.Drawing.Point(4, 1034);
-            this.panel_invoiceAddressButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_invoiceAddressButton.Name = "panel_invoiceAddressButton";
-            this.panel_invoiceAddressButton.Size = new System.Drawing.Size(609, 53);
-            this.panel_invoiceAddressButton.TabIndex = 2;
+            panel_invoiceAddressButton.Controls.Add(label_invoiceAddress);
+            panel_invoiceAddressButton.Controls.Add(button_invoiceAddress);
+            panel_invoiceAddressButton.Location = new System.Drawing.Point(3, 621);
+            panel_invoiceAddressButton.Name = "panel_invoiceAddressButton";
+            panel_invoiceAddressButton.Size = new System.Drawing.Size(426, 32);
+            panel_invoiceAddressButton.TabIndex = 2;
             // 
             // label_invoiceAddress
             // 
-            this.label_invoiceAddress.AutoSize = true;
-            this.label_invoiceAddress.ForeColor = System.Drawing.Color.Black;
-            this.label_invoiceAddress.Location = new System.Drawing.Point(64, 13);
-            this.label_invoiceAddress.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_invoiceAddress.Name = "label_invoiceAddress";
-            this.label_invoiceAddress.Size = new System.Drawing.Size(104, 17);
-            this.label_invoiceAddress.TabIndex = 1;
-            this.label_invoiceAddress.Text = "Invoice Address";
+            label_invoiceAddress.AutoSize = true;
+            label_invoiceAddress.ForeColor = System.Drawing.Color.Black;
+            label_invoiceAddress.Location = new System.Drawing.Point(45, 8);
+            label_invoiceAddress.Name = "label_invoiceAddress";
+            label_invoiceAddress.Size = new System.Drawing.Size(104, 17);
+            label_invoiceAddress.TabIndex = 1;
+            label_invoiceAddress.Text = "Invoice Address";
             // 
             // button_invoiceAddress
             // 
-            this.button_invoiceAddress.BackColor = System.Drawing.Color.White;
-            this.button_invoiceAddress.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button_invoiceAddress.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_invoiceAddress.FlatAppearance.BorderSize = 0;
-            this.button_invoiceAddress.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_invoiceAddress.Location = new System.Drawing.Point(13, 2);
-            this.button_invoiceAddress.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_invoiceAddress.Name = "button_invoiceAddress";
-            this.button_invoiceAddress.Size = new System.Drawing.Size(43, 50);
-            this.button_invoiceAddress.TabIndex = 0;
-            this.button_invoiceAddress.UseVisualStyleBackColor = false;
-            this.button_invoiceAddress.Click += new System.EventHandler(this.button_expand_Click);
+            button_invoiceAddress.BackColor = System.Drawing.Color.White;
+            button_invoiceAddress.BackgroundImageLayout = ImageLayout.Stretch;
+            button_invoiceAddress.Cursor = Cursors.Hand;
+            button_invoiceAddress.FlatAppearance.BorderSize = 0;
+            button_invoiceAddress.FlatStyle = FlatStyle.Flat;
+            button_invoiceAddress.Location = new System.Drawing.Point(9, 1);
+            button_invoiceAddress.Name = "button_invoiceAddress";
+            button_invoiceAddress.Size = new System.Drawing.Size(30, 30);
+            button_invoiceAddress.TabIndex = 0;
+            button_invoiceAddress.UseVisualStyleBackColor = false;
+            button_invoiceAddress.Click += button_expand_Click;
             // 
             // panel_invoiceAddress
             // 
-            this.panel_invoiceAddress.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
-            this.panel_invoiceAddress.Controls.Add(this.checkBox_defaultInvoicingAddressCountryISO);
-            this.panel_invoiceAddress.Controls.Add(this.label_useInvoicingAddress);
-            this.panel_invoiceAddress.Controls.Add(this.label_invoicingAddress);
-            this.panel_invoiceAddress.Controls.Add(this.label_invoicingAddressCity);
-            this.panel_invoiceAddress.Controls.Add(this.label_invoicingAddressZipCode);
-            this.panel_invoiceAddress.Controls.Add(this.label_invoicingAddress2);
-            this.panel_invoiceAddress.Controls.Add(this.label_invoicingAddress3);
-            this.panel_invoiceAddress.Controls.Add(this.label_invoicingAddressState);
-            this.panel_invoiceAddress.Controls.Add(this.label_invoicingAddressCountryID);
-            this.panel_invoiceAddress.Controls.Add(this.comboBox_useInvoicingAddress);
-            this.panel_invoiceAddress.Controls.Add(this.comboBox_invoicingAddress);
-            this.panel_invoiceAddress.Controls.Add(this.comboBox_invoicingAddress2);
-            this.panel_invoiceAddress.Controls.Add(this.comboBox_invoicingAddress3);
-            this.panel_invoiceAddress.Controls.Add(this.comboBox_invoicingAddressZipCode);
-            this.panel_invoiceAddress.Controls.Add(this.comboBox_invoicingAddressCity);
-            this.panel_invoiceAddress.Controls.Add(this.comboBox_invoicingAddressState);
-            this.panel_invoiceAddress.Controls.Add(this.comboBox_invoicingAddressCountryISO);
-            this.panel_invoiceAddress.Location = new System.Drawing.Point(4, 1097);
-            this.panel_invoiceAddress.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_invoiceAddress.MaximumSize = new System.Drawing.Size(609, 442);
-            this.panel_invoiceAddress.MinimumSize = new System.Drawing.Size(609, 0);
-            this.panel_invoiceAddress.Name = "panel_invoiceAddress";
-            this.panel_invoiceAddress.Size = new System.Drawing.Size(609, 442);
-            this.panel_invoiceAddress.TabIndex = 3;
+            panel_invoiceAddress.BackColor = System.Drawing.Color.FromArgb(224, 224, 224);
+            panel_invoiceAddress.Controls.Add(checkBox_defaultInvoicingAddressCountryISO);
+            panel_invoiceAddress.Controls.Add(label_useInvoicingAddress);
+            panel_invoiceAddress.Controls.Add(label_invoicingAddress);
+            panel_invoiceAddress.Controls.Add(label_invoicingAddressCity);
+            panel_invoiceAddress.Controls.Add(label_invoicingAddressZipCode);
+            panel_invoiceAddress.Controls.Add(label_invoicingAddress2);
+            panel_invoiceAddress.Controls.Add(label_invoicingAddress3);
+            panel_invoiceAddress.Controls.Add(label_invoicingAddressState);
+            panel_invoiceAddress.Controls.Add(label_invoicingAddressCountryID);
+            panel_invoiceAddress.Controls.Add(comboBox_useInvoicingAddress);
+            panel_invoiceAddress.Controls.Add(comboBox_invoicingAddress);
+            panel_invoiceAddress.Controls.Add(comboBox_invoicingAddress2);
+            panel_invoiceAddress.Controls.Add(comboBox_invoicingAddress3);
+            panel_invoiceAddress.Controls.Add(comboBox_invoicingAddressZipCode);
+            panel_invoiceAddress.Controls.Add(comboBox_invoicingAddressCity);
+            panel_invoiceAddress.Controls.Add(comboBox_invoicingAddressState);
+            panel_invoiceAddress.Controls.Add(comboBox_invoicingAddressCountryISO);
+            panel_invoiceAddress.Location = new System.Drawing.Point(3, 659);
+            panel_invoiceAddress.MaximumSize = new System.Drawing.Size(426, 265);
+            panel_invoiceAddress.MinimumSize = new System.Drawing.Size(426, 0);
+            panel_invoiceAddress.Name = "panel_invoiceAddress";
+            panel_invoiceAddress.Size = new System.Drawing.Size(426, 265);
+            panel_invoiceAddress.TabIndex = 3;
             // 
             // checkBox_defaultInvoicingAddressCountryISO
             // 
-            this.checkBox_defaultInvoicingAddressCountryISO.AutoSize = true;
-            this.checkBox_defaultInvoicingAddressCountryISO.Location = new System.Drawing.Point(487, 385);
-            this.checkBox_defaultInvoicingAddressCountryISO.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultInvoicingAddressCountryISO.Name = "checkBox_defaultInvoicingAddressCountryISO";
-            this.checkBox_defaultInvoicingAddressCountryISO.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultInvoicingAddressCountryISO.TabIndex = 6;
-            this.checkBox_defaultInvoicingAddressCountryISO.Text = "Default";
-            this.checkBox_defaultInvoicingAddressCountryISO.UseVisualStyleBackColor = true;
-            this.checkBox_defaultInvoicingAddressCountryISO.CheckedChanged += new System.EventHandler(this.checkBox_defaultInvoiceAddressCountryISO_CheckedChanged);
+            checkBox_defaultInvoicingAddressCountryISO.AutoSize = true;
+            checkBox_defaultInvoicingAddressCountryISO.Location = new System.Drawing.Point(341, 231);
+            checkBox_defaultInvoicingAddressCountryISO.Name = "checkBox_defaultInvoicingAddressCountryISO";
+            checkBox_defaultInvoicingAddressCountryISO.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultInvoicingAddressCountryISO.TabIndex = 6;
+            checkBox_defaultInvoicingAddressCountryISO.Text = "Default";
+            checkBox_defaultInvoicingAddressCountryISO.UseVisualStyleBackColor = true;
+            checkBox_defaultInvoicingAddressCountryISO.CheckedChanged += checkBox_defaultInvoiceAddressCountryISO_CheckedChanged;
             // 
             // label_useInvoicingAddress
             // 
-            this.label_useInvoicingAddress.AutoSize = true;
-            this.label_useInvoicingAddress.Location = new System.Drawing.Point(14, 25);
-            this.label_useInvoicingAddress.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_useInvoicingAddress.Name = "label_useInvoicingAddress";
-            this.label_useInvoicingAddress.Size = new System.Drawing.Size(142, 17);
-            this.label_useInvoicingAddress.TabIndex = 1;
-            this.label_useInvoicingAddress.Text = "Use Invoicing Address";
+            label_useInvoicingAddress.AutoSize = true;
+            label_useInvoicingAddress.Location = new System.Drawing.Point(10, 15);
+            label_useInvoicingAddress.Name = "label_useInvoicingAddress";
+            label_useInvoicingAddress.Size = new System.Drawing.Size(142, 17);
+            label_useInvoicingAddress.TabIndex = 1;
+            label_useInvoicingAddress.Text = "Use Invoicing Address";
             // 
             // label_invoicingAddress
             // 
-            this.label_invoicingAddress.AutoSize = true;
-            this.label_invoicingAddress.Location = new System.Drawing.Point(14, 77);
-            this.label_invoicingAddress.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_invoicingAddress.Name = "label_invoicingAddress";
-            this.label_invoicingAddress.Size = new System.Drawing.Size(116, 17);
-            this.label_invoicingAddress.TabIndex = 1;
-            this.label_invoicingAddress.Text = "Invoicing Address";
+            label_invoicingAddress.AutoSize = true;
+            label_invoicingAddress.Location = new System.Drawing.Point(10, 46);
+            label_invoicingAddress.Name = "label_invoicingAddress";
+            label_invoicingAddress.Size = new System.Drawing.Size(116, 17);
+            label_invoicingAddress.TabIndex = 1;
+            label_invoicingAddress.Text = "Invoicing Address";
             // 
             // label_invoicingAddressCity
             // 
-            this.label_invoicingAddressCity.AutoSize = true;
-            this.label_invoicingAddressCity.Location = new System.Drawing.Point(14, 283);
-            this.label_invoicingAddressCity.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_invoicingAddressCity.Name = "label_invoicingAddressCity";
-            this.label_invoicingAddressCity.Size = new System.Drawing.Size(143, 17);
-            this.label_invoicingAddressCity.TabIndex = 1;
-            this.label_invoicingAddressCity.Text = "Invoicing Address City";
+            label_invoicingAddressCity.AutoSize = true;
+            label_invoicingAddressCity.Location = new System.Drawing.Point(10, 170);
+            label_invoicingAddressCity.Name = "label_invoicingAddressCity";
+            label_invoicingAddressCity.Size = new System.Drawing.Size(143, 17);
+            label_invoicingAddressCity.TabIndex = 1;
+            label_invoicingAddressCity.Text = "Invoicing Address City";
             // 
             // label_invoicingAddressZipCode
             // 
-            this.label_invoicingAddressZipCode.AutoSize = true;
-            this.label_invoicingAddressZipCode.Location = new System.Drawing.Point(14, 232);
-            this.label_invoicingAddressZipCode.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_invoicingAddressZipCode.Name = "label_invoicingAddressZipCode";
-            this.label_invoicingAddressZipCode.Size = new System.Drawing.Size(174, 17);
-            this.label_invoicingAddressZipCode.TabIndex = 1;
-            this.label_invoicingAddressZipCode.Text = "Invoicing Address Zip Code";
+            label_invoicingAddressZipCode.AutoSize = true;
+            label_invoicingAddressZipCode.Location = new System.Drawing.Point(10, 139);
+            label_invoicingAddressZipCode.Name = "label_invoicingAddressZipCode";
+            label_invoicingAddressZipCode.Size = new System.Drawing.Size(174, 17);
+            label_invoicingAddressZipCode.TabIndex = 1;
+            label_invoicingAddressZipCode.Text = "Invoicing Address Zip Code";
             // 
             // label_invoicingAddress2
             // 
-            this.label_invoicingAddress2.AutoSize = true;
-            this.label_invoicingAddress2.Location = new System.Drawing.Point(14, 128);
-            this.label_invoicingAddress2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_invoicingAddress2.Name = "label_invoicingAddress2";
-            this.label_invoicingAddress2.Size = new System.Drawing.Size(127, 17);
-            this.label_invoicingAddress2.TabIndex = 1;
-            this.label_invoicingAddress2.Text = "Invoicing Address 2";
+            label_invoicingAddress2.AutoSize = true;
+            label_invoicingAddress2.Location = new System.Drawing.Point(10, 77);
+            label_invoicingAddress2.Name = "label_invoicingAddress2";
+            label_invoicingAddress2.Size = new System.Drawing.Size(127, 17);
+            label_invoicingAddress2.TabIndex = 1;
+            label_invoicingAddress2.Text = "Invoicing Address 2";
             // 
             // label_invoicingAddress3
             // 
-            this.label_invoicingAddress3.AutoSize = true;
-            this.label_invoicingAddress3.Location = new System.Drawing.Point(14, 180);
-            this.label_invoicingAddress3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_invoicingAddress3.Name = "label_invoicingAddress3";
-            this.label_invoicingAddress3.Size = new System.Drawing.Size(127, 17);
-            this.label_invoicingAddress3.TabIndex = 1;
-            this.label_invoicingAddress3.Text = "Invoicing Address 3";
+            label_invoicingAddress3.AutoSize = true;
+            label_invoicingAddress3.Location = new System.Drawing.Point(10, 108);
+            label_invoicingAddress3.Name = "label_invoicingAddress3";
+            label_invoicingAddress3.Size = new System.Drawing.Size(127, 17);
+            label_invoicingAddress3.TabIndex = 1;
+            label_invoicingAddress3.Text = "Invoicing Address 3";
             // 
             // label_invoicingAddressState
             // 
-            this.label_invoicingAddressState.AutoSize = true;
-            this.label_invoicingAddressState.Location = new System.Drawing.Point(14, 335);
-            this.label_invoicingAddressState.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_invoicingAddressState.Name = "label_invoicingAddressState";
-            this.label_invoicingAddressState.Size = new System.Drawing.Size(151, 17);
-            this.label_invoicingAddressState.TabIndex = 1;
-            this.label_invoicingAddressState.Text = "Invoicing Address State";
+            label_invoicingAddressState.AutoSize = true;
+            label_invoicingAddressState.Location = new System.Drawing.Point(10, 201);
+            label_invoicingAddressState.Name = "label_invoicingAddressState";
+            label_invoicingAddressState.Size = new System.Drawing.Size(151, 17);
+            label_invoicingAddressState.TabIndex = 1;
+            label_invoicingAddressState.Text = "Invoicing Address State";
             // 
             // label_invoicingAddressCountryID
             // 
-            this.label_invoicingAddressCountryID.AutoSize = true;
-            this.label_invoicingAddressCountryID.Location = new System.Drawing.Point(14, 387);
-            this.label_invoicingAddressCountryID.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_invoicingAddressCountryID.Name = "label_invoicingAddressCountryID";
-            this.label_invoicingAddressCountryID.Size = new System.Drawing.Size(187, 17);
-            this.label_invoicingAddressCountryID.TabIndex = 5;
-            this.label_invoicingAddressCountryID.Text = "Invoicing Address Country ID";
+            label_invoicingAddressCountryID.AutoSize = true;
+            label_invoicingAddressCountryID.Location = new System.Drawing.Point(10, 232);
+            label_invoicingAddressCountryID.Name = "label_invoicingAddressCountryID";
+            label_invoicingAddressCountryID.Size = new System.Drawing.Size(187, 17);
+            label_invoicingAddressCountryID.TabIndex = 5;
+            label_invoicingAddressCountryID.Text = "Invoicing Address Country ID";
             // 
             // comboBox_useInvoicingAddress
             // 
-            this.comboBox_useInvoicingAddress.FormattingEnabled = true;
-            this.comboBox_useInvoicingAddress.Location = new System.Drawing.Point(289, 20);
-            this.comboBox_useInvoicingAddress.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_useInvoicingAddress.Name = "comboBox_useInvoicingAddress";
-            this.comboBox_useInvoicingAddress.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_useInvoicingAddress.TabIndex = 3;
+            comboBox_useInvoicingAddress.FormattingEnabled = true;
+            comboBox_useInvoicingAddress.Location = new System.Drawing.Point(202, 12);
+            comboBox_useInvoicingAddress.Name = "comboBox_useInvoicingAddress";
+            comboBox_useInvoicingAddress.Size = new System.Drawing.Size(133, 25);
+            comboBox_useInvoicingAddress.TabIndex = 3;
             // 
             // comboBox_invoicingAddress
             // 
-            this.comboBox_invoicingAddress.FormattingEnabled = true;
-            this.comboBox_invoicingAddress.Location = new System.Drawing.Point(289, 72);
-            this.comboBox_invoicingAddress.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_invoicingAddress.Name = "comboBox_invoicingAddress";
-            this.comboBox_invoicingAddress.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_invoicingAddress.TabIndex = 3;
+            comboBox_invoicingAddress.FormattingEnabled = true;
+            comboBox_invoicingAddress.Location = new System.Drawing.Point(202, 43);
+            comboBox_invoicingAddress.Name = "comboBox_invoicingAddress";
+            comboBox_invoicingAddress.Size = new System.Drawing.Size(133, 25);
+            comboBox_invoicingAddress.TabIndex = 3;
             // 
             // comboBox_invoicingAddress2
             // 
-            this.comboBox_invoicingAddress2.FormattingEnabled = true;
-            this.comboBox_invoicingAddress2.Location = new System.Drawing.Point(289, 123);
-            this.comboBox_invoicingAddress2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_invoicingAddress2.Name = "comboBox_invoicingAddress2";
-            this.comboBox_invoicingAddress2.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_invoicingAddress2.TabIndex = 3;
+            comboBox_invoicingAddress2.FormattingEnabled = true;
+            comboBox_invoicingAddress2.Location = new System.Drawing.Point(202, 74);
+            comboBox_invoicingAddress2.Name = "comboBox_invoicingAddress2";
+            comboBox_invoicingAddress2.Size = new System.Drawing.Size(133, 25);
+            comboBox_invoicingAddress2.TabIndex = 3;
             // 
             // comboBox_invoicingAddress3
             // 
-            this.comboBox_invoicingAddress3.FormattingEnabled = true;
-            this.comboBox_invoicingAddress3.Location = new System.Drawing.Point(289, 175);
-            this.comboBox_invoicingAddress3.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_invoicingAddress3.Name = "comboBox_invoicingAddress3";
-            this.comboBox_invoicingAddress3.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_invoicingAddress3.TabIndex = 3;
+            comboBox_invoicingAddress3.FormattingEnabled = true;
+            comboBox_invoicingAddress3.Location = new System.Drawing.Point(202, 105);
+            comboBox_invoicingAddress3.Name = "comboBox_invoicingAddress3";
+            comboBox_invoicingAddress3.Size = new System.Drawing.Size(133, 25);
+            comboBox_invoicingAddress3.TabIndex = 3;
             // 
             // comboBox_invoicingAddressZipCode
             // 
-            this.comboBox_invoicingAddressZipCode.FormattingEnabled = true;
-            this.comboBox_invoicingAddressZipCode.Location = new System.Drawing.Point(289, 227);
-            this.comboBox_invoicingAddressZipCode.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_invoicingAddressZipCode.Name = "comboBox_invoicingAddressZipCode";
-            this.comboBox_invoicingAddressZipCode.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_invoicingAddressZipCode.TabIndex = 3;
+            comboBox_invoicingAddressZipCode.FormattingEnabled = true;
+            comboBox_invoicingAddressZipCode.Location = new System.Drawing.Point(202, 136);
+            comboBox_invoicingAddressZipCode.Name = "comboBox_invoicingAddressZipCode";
+            comboBox_invoicingAddressZipCode.Size = new System.Drawing.Size(133, 25);
+            comboBox_invoicingAddressZipCode.TabIndex = 3;
             // 
             // comboBox_invoicingAddressCity
             // 
-            this.comboBox_invoicingAddressCity.FormattingEnabled = true;
-            this.comboBox_invoicingAddressCity.Location = new System.Drawing.Point(289, 278);
-            this.comboBox_invoicingAddressCity.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_invoicingAddressCity.Name = "comboBox_invoicingAddressCity";
-            this.comboBox_invoicingAddressCity.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_invoicingAddressCity.TabIndex = 3;
+            comboBox_invoicingAddressCity.FormattingEnabled = true;
+            comboBox_invoicingAddressCity.Location = new System.Drawing.Point(202, 167);
+            comboBox_invoicingAddressCity.Name = "comboBox_invoicingAddressCity";
+            comboBox_invoicingAddressCity.Size = new System.Drawing.Size(133, 25);
+            comboBox_invoicingAddressCity.TabIndex = 3;
             // 
             // comboBox_invoicingAddressState
             // 
-            this.comboBox_invoicingAddressState.FormattingEnabled = true;
-            this.comboBox_invoicingAddressState.Location = new System.Drawing.Point(289, 330);
-            this.comboBox_invoicingAddressState.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_invoicingAddressState.Name = "comboBox_invoicingAddressState";
-            this.comboBox_invoicingAddressState.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_invoicingAddressState.TabIndex = 3;
+            comboBox_invoicingAddressState.FormattingEnabled = true;
+            comboBox_invoicingAddressState.Location = new System.Drawing.Point(202, 198);
+            comboBox_invoicingAddressState.Name = "comboBox_invoicingAddressState";
+            comboBox_invoicingAddressState.Size = new System.Drawing.Size(133, 25);
+            comboBox_invoicingAddressState.TabIndex = 3;
             // 
             // comboBox_invoicingAddressCountryISO
             // 
-            this.comboBox_invoicingAddressCountryISO.FormattingEnabled = true;
-            this.comboBox_invoicingAddressCountryISO.Location = new System.Drawing.Point(289, 382);
-            this.comboBox_invoicingAddressCountryISO.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_invoicingAddressCountryISO.Name = "comboBox_invoicingAddressCountryISO";
-            this.comboBox_invoicingAddressCountryISO.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_invoicingAddressCountryISO.TabIndex = 3;
+            comboBox_invoicingAddressCountryISO.FormattingEnabled = true;
+            comboBox_invoicingAddressCountryISO.Location = new System.Drawing.Point(202, 229);
+            comboBox_invoicingAddressCountryISO.Name = "comboBox_invoicingAddressCountryISO";
+            comboBox_invoicingAddressCountryISO.Size = new System.Drawing.Size(133, 25);
+            comboBox_invoicingAddressCountryISO.TabIndex = 3;
             // 
             // panel2
             // 
-            this.panel2.Controls.Add(this.label_financeCompanyInfo);
-            this.panel2.Controls.Add(this.button_financeCompanyInfo);
-            this.panel2.Location = new System.Drawing.Point(4, 1549);
-            this.panel2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(609, 53);
-            this.panel2.TabIndex = 4;
+            panel2.Controls.Add(label_financeCompanyInfo);
+            panel2.Controls.Add(button_financeCompanyInfo);
+            panel2.Location = new System.Drawing.Point(3, 930);
+            panel2.Name = "panel2";
+            panel2.Size = new System.Drawing.Size(426, 32);
+            panel2.TabIndex = 4;
             // 
             // label_financeCompanyInfo
             // 
-            this.label_financeCompanyInfo.AutoSize = true;
-            this.label_financeCompanyInfo.ForeColor = System.Drawing.Color.Black;
-            this.label_financeCompanyInfo.Location = new System.Drawing.Point(64, 13);
-            this.label_financeCompanyInfo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_financeCompanyInfo.Name = "label_financeCompanyInfo";
-            this.label_financeCompanyInfo.Size = new System.Drawing.Size(153, 17);
-            this.label_financeCompanyInfo.TabIndex = 1;
-            this.label_financeCompanyInfo.Text = "Finance - Company Info";
+            label_financeCompanyInfo.AutoSize = true;
+            label_financeCompanyInfo.ForeColor = System.Drawing.Color.Black;
+            label_financeCompanyInfo.Location = new System.Drawing.Point(45, 8);
+            label_financeCompanyInfo.Name = "label_financeCompanyInfo";
+            label_financeCompanyInfo.Size = new System.Drawing.Size(153, 17);
+            label_financeCompanyInfo.TabIndex = 1;
+            label_financeCompanyInfo.Text = "Finance - Company Info";
             // 
             // button_financeCompanyInfo
             // 
-            this.button_financeCompanyInfo.BackColor = System.Drawing.Color.White;
-            this.button_financeCompanyInfo.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button_financeCompanyInfo.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_financeCompanyInfo.FlatAppearance.BorderSize = 0;
-            this.button_financeCompanyInfo.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_financeCompanyInfo.Location = new System.Drawing.Point(13, 2);
-            this.button_financeCompanyInfo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_financeCompanyInfo.Name = "button_financeCompanyInfo";
-            this.button_financeCompanyInfo.Size = new System.Drawing.Size(43, 50);
-            this.button_financeCompanyInfo.TabIndex = 0;
-            this.button_financeCompanyInfo.UseVisualStyleBackColor = false;
-            this.button_financeCompanyInfo.Click += new System.EventHandler(this.button_expand_Click);
+            button_financeCompanyInfo.BackColor = System.Drawing.Color.White;
+            button_financeCompanyInfo.BackgroundImageLayout = ImageLayout.Stretch;
+            button_financeCompanyInfo.Cursor = Cursors.Hand;
+            button_financeCompanyInfo.FlatAppearance.BorderSize = 0;
+            button_financeCompanyInfo.FlatStyle = FlatStyle.Flat;
+            button_financeCompanyInfo.Location = new System.Drawing.Point(9, 1);
+            button_financeCompanyInfo.Name = "button_financeCompanyInfo";
+            button_financeCompanyInfo.Size = new System.Drawing.Size(30, 30);
+            button_financeCompanyInfo.TabIndex = 0;
+            button_financeCompanyInfo.UseVisualStyleBackColor = false;
+            button_financeCompanyInfo.Click += button_expand_Click;
             // 
             // panel_financeCompanyInfo
             // 
-            this.panel_financeCompanyInfo.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
-            this.panel_financeCompanyInfo.Controls.Add(this.label_organizationNo);
-            this.panel_financeCompanyInfo.Controls.Add(this.label_vatNo);
-            this.panel_financeCompanyInfo.Controls.Add(this.comboBox_organizationNo);
-            this.panel_financeCompanyInfo.Controls.Add(this.comboBox_VATNo);
-            this.panel_financeCompanyInfo.Controls.Add(this.comboBox_eanNo);
-            this.panel_financeCompanyInfo.Controls.Add(this.comboBox_useEanNo);
-            this.panel_financeCompanyInfo.Controls.Add(this.label_eanNo);
-            this.panel_financeCompanyInfo.Controls.Add(this.label_useEanNo);
-            this.panel_financeCompanyInfo.Location = new System.Drawing.Point(4, 1612);
-            this.panel_financeCompanyInfo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_financeCompanyInfo.MaximumSize = new System.Drawing.Size(609, 235);
-            this.panel_financeCompanyInfo.MinimumSize = new System.Drawing.Size(609, 0);
-            this.panel_financeCompanyInfo.Name = "panel_financeCompanyInfo";
-            this.panel_financeCompanyInfo.Size = new System.Drawing.Size(609, 235);
-            this.panel_financeCompanyInfo.TabIndex = 5;
+            panel_financeCompanyInfo.BackColor = System.Drawing.Color.FromArgb(224, 224, 224);
+            panel_financeCompanyInfo.Controls.Add(label_organizationNo);
+            panel_financeCompanyInfo.Controls.Add(label_vatNo);
+            panel_financeCompanyInfo.Controls.Add(comboBox_organizationNo);
+            panel_financeCompanyInfo.Controls.Add(comboBox_VATNo);
+            panel_financeCompanyInfo.Controls.Add(comboBox_eanNo);
+            panel_financeCompanyInfo.Controls.Add(comboBox_useEanNo);
+            panel_financeCompanyInfo.Controls.Add(label_eanNo);
+            panel_financeCompanyInfo.Controls.Add(label_useEanNo);
+            panel_financeCompanyInfo.Location = new System.Drawing.Point(3, 968);
+            panel_financeCompanyInfo.MaximumSize = new System.Drawing.Size(426, 141);
+            panel_financeCompanyInfo.MinimumSize = new System.Drawing.Size(426, 0);
+            panel_financeCompanyInfo.Name = "panel_financeCompanyInfo";
+            panel_financeCompanyInfo.Size = new System.Drawing.Size(426, 141);
+            panel_financeCompanyInfo.TabIndex = 5;
             // 
             // label_organizationNo
             // 
-            this.label_organizationNo.AutoSize = true;
-            this.label_organizationNo.Location = new System.Drawing.Point(14, 25);
-            this.label_organizationNo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_organizationNo.Name = "label_organizationNo";
-            this.label_organizationNo.Size = new System.Drawing.Size(108, 17);
-            this.label_organizationNo.TabIndex = 1;
-            this.label_organizationNo.Text = "Organization No";
+            label_organizationNo.AutoSize = true;
+            label_organizationNo.Location = new System.Drawing.Point(10, 15);
+            label_organizationNo.Name = "label_organizationNo";
+            label_organizationNo.Size = new System.Drawing.Size(108, 17);
+            label_organizationNo.TabIndex = 1;
+            label_organizationNo.Text = "Organization No";
             // 
             // label_vatNo
             // 
-            this.label_vatNo.AutoSize = true;
-            this.label_vatNo.Location = new System.Drawing.Point(14, 77);
-            this.label_vatNo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_vatNo.Name = "label_vatNo";
-            this.label_vatNo.Size = new System.Drawing.Size(52, 17);
-            this.label_vatNo.TabIndex = 1;
-            this.label_vatNo.Text = "VAT No";
+            label_vatNo.AutoSize = true;
+            label_vatNo.Location = new System.Drawing.Point(10, 46);
+            label_vatNo.Name = "label_vatNo";
+            label_vatNo.Size = new System.Drawing.Size(52, 17);
+            label_vatNo.TabIndex = 1;
+            label_vatNo.Text = "VAT No";
             // 
             // comboBox_organizationNo
             // 
-            this.comboBox_organizationNo.FormattingEnabled = true;
-            this.comboBox_organizationNo.Location = new System.Drawing.Point(193, 20);
-            this.comboBox_organizationNo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_organizationNo.Name = "comboBox_organizationNo";
-            this.comboBox_organizationNo.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_organizationNo.TabIndex = 3;
+            comboBox_organizationNo.FormattingEnabled = true;
+            comboBox_organizationNo.Location = new System.Drawing.Point(135, 12);
+            comboBox_organizationNo.Name = "comboBox_organizationNo";
+            comboBox_organizationNo.Size = new System.Drawing.Size(133, 25);
+            comboBox_organizationNo.TabIndex = 3;
             // 
             // comboBox_VATNo
             // 
-            this.comboBox_VATNo.FormattingEnabled = true;
-            this.comboBox_VATNo.Location = new System.Drawing.Point(193, 72);
-            this.comboBox_VATNo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_VATNo.Name = "comboBox_VATNo";
-            this.comboBox_VATNo.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_VATNo.TabIndex = 3;
+            comboBox_VATNo.FormattingEnabled = true;
+            comboBox_VATNo.Location = new System.Drawing.Point(135, 43);
+            comboBox_VATNo.Name = "comboBox_VATNo";
+            comboBox_VATNo.Size = new System.Drawing.Size(133, 25);
+            comboBox_VATNo.TabIndex = 3;
             // 
             // comboBox_eanNo
             // 
-            this.comboBox_eanNo.FormattingEnabled = true;
-            this.comboBox_eanNo.Location = new System.Drawing.Point(193, 175);
-            this.comboBox_eanNo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_eanNo.Name = "comboBox_eanNo";
-            this.comboBox_eanNo.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_eanNo.TabIndex = 3;
+            comboBox_eanNo.FormattingEnabled = true;
+            comboBox_eanNo.Location = new System.Drawing.Point(135, 105);
+            comboBox_eanNo.Name = "comboBox_eanNo";
+            comboBox_eanNo.Size = new System.Drawing.Size(133, 25);
+            comboBox_eanNo.TabIndex = 3;
             // 
             // comboBox_useEanNo
             // 
-            this.comboBox_useEanNo.FormattingEnabled = true;
-            this.comboBox_useEanNo.Location = new System.Drawing.Point(193, 123);
-            this.comboBox_useEanNo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_useEanNo.Name = "comboBox_useEanNo";
-            this.comboBox_useEanNo.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_useEanNo.TabIndex = 3;
+            comboBox_useEanNo.FormattingEnabled = true;
+            comboBox_useEanNo.Location = new System.Drawing.Point(135, 74);
+            comboBox_useEanNo.Name = "comboBox_useEanNo";
+            comboBox_useEanNo.Size = new System.Drawing.Size(133, 25);
+            comboBox_useEanNo.TabIndex = 3;
             // 
             // label_eanNo
             // 
-            this.label_eanNo.AutoSize = true;
-            this.label_eanNo.Location = new System.Drawing.Point(14, 180);
-            this.label_eanNo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_eanNo.Name = "label_eanNo";
-            this.label_eanNo.Size = new System.Drawing.Size(52, 17);
-            this.label_eanNo.TabIndex = 1;
-            this.label_eanNo.Text = "Ean No";
+            label_eanNo.AutoSize = true;
+            label_eanNo.Location = new System.Drawing.Point(10, 108);
+            label_eanNo.Name = "label_eanNo";
+            label_eanNo.Size = new System.Drawing.Size(52, 17);
+            label_eanNo.TabIndex = 1;
+            label_eanNo.Text = "Ean No";
             // 
             // label_useEanNo
             // 
-            this.label_useEanNo.AutoSize = true;
-            this.label_useEanNo.Location = new System.Drawing.Point(14, 128);
-            this.label_useEanNo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_useEanNo.Name = "label_useEanNo";
-            this.label_useEanNo.Size = new System.Drawing.Size(78, 17);
-            this.label_useEanNo.TabIndex = 1;
-            this.label_useEanNo.Text = "Use Ean No";
+            label_useEanNo.AutoSize = true;
+            label_useEanNo.Location = new System.Drawing.Point(10, 77);
+            label_useEanNo.Name = "label_useEanNo";
+            label_useEanNo.Size = new System.Drawing.Size(78, 17);
+            label_useEanNo.TabIndex = 1;
+            label_useEanNo.Text = "Use Ean No";
             // 
             // panel_defaultInvoiceSettingsButton
             // 
-            this.panel_defaultInvoiceSettingsButton.Controls.Add(this.label_defaultInvoiceSettings);
-            this.panel_defaultInvoiceSettingsButton.Controls.Add(this.button_defaultInvoiceSettings);
-            this.panel_defaultInvoiceSettingsButton.Location = new System.Drawing.Point(4, 1857);
-            this.panel_defaultInvoiceSettingsButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_defaultInvoiceSettingsButton.Name = "panel_defaultInvoiceSettingsButton";
-            this.panel_defaultInvoiceSettingsButton.Size = new System.Drawing.Size(609, 53);
-            this.panel_defaultInvoiceSettingsButton.TabIndex = 6;
+            panel_defaultInvoiceSettingsButton.Controls.Add(label_defaultInvoiceSettings);
+            panel_defaultInvoiceSettingsButton.Controls.Add(button_defaultInvoiceSettings);
+            panel_defaultInvoiceSettingsButton.Location = new System.Drawing.Point(3, 1115);
+            panel_defaultInvoiceSettingsButton.Name = "panel_defaultInvoiceSettingsButton";
+            panel_defaultInvoiceSettingsButton.Size = new System.Drawing.Size(426, 32);
+            panel_defaultInvoiceSettingsButton.TabIndex = 6;
             // 
             // label_defaultInvoiceSettings
             // 
-            this.label_defaultInvoiceSettings.AutoSize = true;
-            this.label_defaultInvoiceSettings.ForeColor = System.Drawing.Color.Black;
-            this.label_defaultInvoiceSettings.Location = new System.Drawing.Point(64, 13);
-            this.label_defaultInvoiceSettings.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_defaultInvoiceSettings.Name = "label_defaultInvoiceSettings";
-            this.label_defaultInvoiceSettings.Size = new System.Drawing.Size(210, 17);
-            this.label_defaultInvoiceSettings.TabIndex = 1;
-            this.label_defaultInvoiceSettings.Text = "Finance - Default Invoice Settings";
+            label_defaultInvoiceSettings.AutoSize = true;
+            label_defaultInvoiceSettings.ForeColor = System.Drawing.Color.Black;
+            label_defaultInvoiceSettings.Location = new System.Drawing.Point(45, 8);
+            label_defaultInvoiceSettings.Name = "label_defaultInvoiceSettings";
+            label_defaultInvoiceSettings.Size = new System.Drawing.Size(210, 17);
+            label_defaultInvoiceSettings.TabIndex = 1;
+            label_defaultInvoiceSettings.Text = "Finance - Default Invoice Settings";
             // 
             // button_defaultInvoiceSettings
             // 
-            this.button_defaultInvoiceSettings.BackColor = System.Drawing.Color.White;
-            this.button_defaultInvoiceSettings.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button_defaultInvoiceSettings.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_defaultInvoiceSettings.FlatAppearance.BorderSize = 0;
-            this.button_defaultInvoiceSettings.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_defaultInvoiceSettings.Location = new System.Drawing.Point(13, 2);
-            this.button_defaultInvoiceSettings.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_defaultInvoiceSettings.Name = "button_defaultInvoiceSettings";
-            this.button_defaultInvoiceSettings.Size = new System.Drawing.Size(43, 50);
-            this.button_defaultInvoiceSettings.TabIndex = 0;
-            this.button_defaultInvoiceSettings.UseVisualStyleBackColor = false;
-            this.button_defaultInvoiceSettings.Click += new System.EventHandler(this.button_expand_Click);
+            button_defaultInvoiceSettings.BackColor = System.Drawing.Color.White;
+            button_defaultInvoiceSettings.BackgroundImageLayout = ImageLayout.Stretch;
+            button_defaultInvoiceSettings.Cursor = Cursors.Hand;
+            button_defaultInvoiceSettings.FlatAppearance.BorderSize = 0;
+            button_defaultInvoiceSettings.FlatStyle = FlatStyle.Flat;
+            button_defaultInvoiceSettings.Location = new System.Drawing.Point(9, 1);
+            button_defaultInvoiceSettings.Name = "button_defaultInvoiceSettings";
+            button_defaultInvoiceSettings.Size = new System.Drawing.Size(30, 30);
+            button_defaultInvoiceSettings.TabIndex = 0;
+            button_defaultInvoiceSettings.UseVisualStyleBackColor = false;
+            button_defaultInvoiceSettings.Click += button_expand_Click;
             // 
             // panel_defaultInvoiceSettings
             // 
-            this.panel_defaultInvoiceSettings.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
-            this.panel_defaultInvoiceSettings.Controls.Add(this.checkBox_defaultVATPercentage);
-            this.panel_defaultInvoiceSettings.Controls.Add(this.checkBox_defaultPaymentTerm);
-            this.panel_defaultInvoiceSettings.Controls.Add(this.label_paymentTerm);
-            this.panel_defaultInvoiceSettings.Controls.Add(this.label_discountPercentage);
-            this.panel_defaultInvoiceSettings.Controls.Add(this.label_calculateVAT);
-            this.panel_defaultInvoiceSettings.Controls.Add(this.comboBox_VATPercentage);
-            this.panel_defaultInvoiceSettings.Controls.Add(this.label_vatPercentage);
-            this.panel_defaultInvoiceSettings.Controls.Add(this.comboBox_calculateVAT);
-            this.panel_defaultInvoiceSettings.Controls.Add(this.comboBox_discountPercentage);
-            this.panel_defaultInvoiceSettings.Controls.Add(this.comboBox_paymentTerm);
-            this.panel_defaultInvoiceSettings.Location = new System.Drawing.Point(4, 1920);
-            this.panel_defaultInvoiceSettings.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_defaultInvoiceSettings.MaximumSize = new System.Drawing.Size(609, 442);
-            this.panel_defaultInvoiceSettings.MinimumSize = new System.Drawing.Size(609, 0);
-            this.panel_defaultInvoiceSettings.Name = "panel_defaultInvoiceSettings";
-            this.panel_defaultInvoiceSettings.Size = new System.Drawing.Size(609, 253);
-            this.panel_defaultInvoiceSettings.TabIndex = 7;
+            panel_defaultInvoiceSettings.BackColor = System.Drawing.Color.FromArgb(224, 224, 224);
+            panel_defaultInvoiceSettings.Controls.Add(checkBox_defaultVATPercentage);
+            panel_defaultInvoiceSettings.Controls.Add(checkBox_defaultPaymentTerm);
+            panel_defaultInvoiceSettings.Controls.Add(label_paymentTerm);
+            panel_defaultInvoiceSettings.Controls.Add(label_discountPercentage);
+            panel_defaultInvoiceSettings.Controls.Add(label_calculateVAT);
+            panel_defaultInvoiceSettings.Controls.Add(comboBox_VATPercentage);
+            panel_defaultInvoiceSettings.Controls.Add(label_vatPercentage);
+            panel_defaultInvoiceSettings.Controls.Add(comboBox_calculateVAT);
+            panel_defaultInvoiceSettings.Controls.Add(comboBox_discountPercentage);
+            panel_defaultInvoiceSettings.Controls.Add(comboBox_paymentTerm);
+            panel_defaultInvoiceSettings.Location = new System.Drawing.Point(3, 1153);
+            panel_defaultInvoiceSettings.MaximumSize = new System.Drawing.Size(426, 265);
+            panel_defaultInvoiceSettings.MinimumSize = new System.Drawing.Size(426, 0);
+            panel_defaultInvoiceSettings.Name = "panel_defaultInvoiceSettings";
+            panel_defaultInvoiceSettings.Size = new System.Drawing.Size(426, 152);
+            panel_defaultInvoiceSettings.TabIndex = 7;
             // 
             // checkBox_defaultVATPercentage
             // 
-            this.checkBox_defaultVATPercentage.AutoSize = true;
-            this.checkBox_defaultVATPercentage.Location = new System.Drawing.Point(473, 179);
-            this.checkBox_defaultVATPercentage.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultVATPercentage.Name = "checkBox_defaultVATPercentage";
-            this.checkBox_defaultVATPercentage.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultVATPercentage.TabIndex = 8;
-            this.checkBox_defaultVATPercentage.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultVATPercentage, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultVATPercentage.UseVisualStyleBackColor = true;
-            this.checkBox_defaultVATPercentage.CheckedChanged += new System.EventHandler(this.checkBox_defaultVATPercentage_CheckedChanged);
+            checkBox_defaultVATPercentage.AutoSize = true;
+            checkBox_defaultVATPercentage.Location = new System.Drawing.Point(331, 107);
+            checkBox_defaultVATPercentage.Name = "checkBox_defaultVATPercentage";
+            checkBox_defaultVATPercentage.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultVATPercentage.TabIndex = 8;
+            checkBox_defaultVATPercentage.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultVATPercentage, "Set default values for all rows of a particular column field");
+            checkBox_defaultVATPercentage.UseVisualStyleBackColor = true;
+            checkBox_defaultVATPercentage.CheckedChanged += checkBox_defaultVATPercentage_CheckedChanged;
             // 
             // checkBox_defaultPaymentTerm
             // 
-            this.checkBox_defaultPaymentTerm.AutoSize = true;
-            this.checkBox_defaultPaymentTerm.Location = new System.Drawing.Point(473, 22);
-            this.checkBox_defaultPaymentTerm.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultPaymentTerm.Name = "checkBox_defaultPaymentTerm";
-            this.checkBox_defaultPaymentTerm.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultPaymentTerm.TabIndex = 8;
-            this.checkBox_defaultPaymentTerm.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultPaymentTerm, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultPaymentTerm.UseVisualStyleBackColor = true;
-            this.checkBox_defaultPaymentTerm.CheckedChanged += new System.EventHandler(this.checkBox_defaultPaymentTerm_CheckedChanged);
+            checkBox_defaultPaymentTerm.AutoSize = true;
+            checkBox_defaultPaymentTerm.Location = new System.Drawing.Point(331, 13);
+            checkBox_defaultPaymentTerm.Name = "checkBox_defaultPaymentTerm";
+            checkBox_defaultPaymentTerm.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultPaymentTerm.TabIndex = 8;
+            checkBox_defaultPaymentTerm.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultPaymentTerm, "Set default values for all rows of a particular column field");
+            checkBox_defaultPaymentTerm.UseVisualStyleBackColor = true;
+            checkBox_defaultPaymentTerm.CheckedChanged += checkBox_defaultPaymentTerm_CheckedChanged;
             // 
             // label_paymentTerm
             // 
-            this.label_paymentTerm.AutoSize = true;
-            this.label_paymentTerm.Location = new System.Drawing.Point(20, 24);
-            this.label_paymentTerm.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_paymentTerm.Name = "label_paymentTerm";
-            this.label_paymentTerm.Size = new System.Drawing.Size(96, 17);
-            this.label_paymentTerm.TabIndex = 1;
-            this.label_paymentTerm.Text = "Payment Term";
+            label_paymentTerm.AutoSize = true;
+            label_paymentTerm.Location = new System.Drawing.Point(14, 14);
+            label_paymentTerm.Name = "label_paymentTerm";
+            label_paymentTerm.Size = new System.Drawing.Size(96, 17);
+            label_paymentTerm.TabIndex = 1;
+            label_paymentTerm.Text = "Payment Term";
             // 
             // label_discountPercentage
             // 
-            this.label_discountPercentage.AutoSize = true;
-            this.label_discountPercentage.Location = new System.Drawing.Point(20, 77);
-            this.label_discountPercentage.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_discountPercentage.Name = "label_discountPercentage";
-            this.label_discountPercentage.Size = new System.Drawing.Size(133, 17);
-            this.label_discountPercentage.TabIndex = 1;
-            this.label_discountPercentage.Text = "Discount Percentage";
+            label_discountPercentage.AutoSize = true;
+            label_discountPercentage.Location = new System.Drawing.Point(14, 46);
+            label_discountPercentage.Name = "label_discountPercentage";
+            label_discountPercentage.Size = new System.Drawing.Size(133, 17);
+            label_discountPercentage.TabIndex = 1;
+            label_discountPercentage.Text = "Discount Percentage";
             // 
             // label_calculateVAT
             // 
-            this.label_calculateVAT.AutoSize = true;
-            this.label_calculateVAT.Location = new System.Drawing.Point(20, 129);
-            this.label_calculateVAT.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_calculateVAT.Name = "label_calculateVAT";
-            this.label_calculateVAT.Size = new System.Drawing.Size(88, 17);
-            this.label_calculateVAT.TabIndex = 1;
-            this.label_calculateVAT.Text = "Calculate VAT";
+            label_calculateVAT.AutoSize = true;
+            label_calculateVAT.Location = new System.Drawing.Point(14, 77);
+            label_calculateVAT.Name = "label_calculateVAT";
+            label_calculateVAT.Size = new System.Drawing.Size(88, 17);
+            label_calculateVAT.TabIndex = 1;
+            label_calculateVAT.Text = "Calculate VAT";
             // 
             // comboBox_VATPercentage
             // 
-            this.comboBox_VATPercentage.FormattingEnabled = true;
-            this.comboBox_VATPercentage.Location = new System.Drawing.Point(247, 176);
-            this.comboBox_VATPercentage.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_VATPercentage.Name = "comboBox_VATPercentage";
-            this.comboBox_VATPercentage.Size = new System.Drawing.Size(215, 25);
-            this.comboBox_VATPercentage.TabIndex = 3;
+            comboBox_VATPercentage.FormattingEnabled = true;
+            comboBox_VATPercentage.Location = new System.Drawing.Point(173, 106);
+            comboBox_VATPercentage.Name = "comboBox_VATPercentage";
+            comboBox_VATPercentage.Size = new System.Drawing.Size(152, 25);
+            comboBox_VATPercentage.TabIndex = 3;
             // 
             // label_vatPercentage
             // 
-            this.label_vatPercentage.AutoSize = true;
-            this.label_vatPercentage.Location = new System.Drawing.Point(20, 181);
-            this.label_vatPercentage.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_vatPercentage.Name = "label_vatPercentage";
-            this.label_vatPercentage.Size = new System.Drawing.Size(102, 17);
-            this.label_vatPercentage.TabIndex = 1;
-            this.label_vatPercentage.Text = "VAT Percentage";
+            label_vatPercentage.AutoSize = true;
+            label_vatPercentage.Location = new System.Drawing.Point(14, 109);
+            label_vatPercentage.Name = "label_vatPercentage";
+            label_vatPercentage.Size = new System.Drawing.Size(102, 17);
+            label_vatPercentage.TabIndex = 1;
+            label_vatPercentage.Text = "VAT Percentage";
             // 
             // comboBox_calculateVAT
             // 
-            this.comboBox_calculateVAT.FormattingEnabled = true;
-            this.comboBox_calculateVAT.Location = new System.Drawing.Point(247, 124);
-            this.comboBox_calculateVAT.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_calculateVAT.Name = "comboBox_calculateVAT";
-            this.comboBox_calculateVAT.Size = new System.Drawing.Size(215, 25);
-            this.comboBox_calculateVAT.TabIndex = 3;
+            comboBox_calculateVAT.FormattingEnabled = true;
+            comboBox_calculateVAT.Location = new System.Drawing.Point(173, 74);
+            comboBox_calculateVAT.Name = "comboBox_calculateVAT";
+            comboBox_calculateVAT.Size = new System.Drawing.Size(152, 25);
+            comboBox_calculateVAT.TabIndex = 3;
             // 
             // comboBox_discountPercentage
             // 
-            this.comboBox_discountPercentage.FormattingEnabled = true;
-            this.comboBox_discountPercentage.Location = new System.Drawing.Point(247, 72);
-            this.comboBox_discountPercentage.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_discountPercentage.Name = "comboBox_discountPercentage";
-            this.comboBox_discountPercentage.Size = new System.Drawing.Size(215, 25);
-            this.comboBox_discountPercentage.TabIndex = 3;
+            comboBox_discountPercentage.FormattingEnabled = true;
+            comboBox_discountPercentage.Location = new System.Drawing.Point(173, 43);
+            comboBox_discountPercentage.Name = "comboBox_discountPercentage";
+            comboBox_discountPercentage.Size = new System.Drawing.Size(152, 25);
+            comboBox_discountPercentage.TabIndex = 3;
             // 
             // comboBox_paymentTerm
             // 
-            this.comboBox_paymentTerm.FormattingEnabled = true;
-            this.comboBox_paymentTerm.Location = new System.Drawing.Point(247, 21);
-            this.comboBox_paymentTerm.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_paymentTerm.Name = "comboBox_paymentTerm";
-            this.comboBox_paymentTerm.Size = new System.Drawing.Size(215, 25);
-            this.comboBox_paymentTerm.TabIndex = 3;
+            comboBox_paymentTerm.FormattingEnabled = true;
+            comboBox_paymentTerm.Location = new System.Drawing.Point(173, 13);
+            comboBox_paymentTerm.Name = "comboBox_paymentTerm";
+            comboBox_paymentTerm.Size = new System.Drawing.Size(152, 25);
+            comboBox_paymentTerm.TabIndex = 3;
             // 
             // panel_invoiceExternalCosts
             // 
-            this.panel_invoiceExternalCosts.Controls.Add(this.label_invoiceExternalCosts);
-            this.panel_invoiceExternalCosts.Controls.Add(this.button_invoiceExternalCosts);
-            this.panel_invoiceExternalCosts.Location = new System.Drawing.Point(4, 2183);
-            this.panel_invoiceExternalCosts.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_invoiceExternalCosts.Name = "panel_invoiceExternalCosts";
-            this.panel_invoiceExternalCosts.Size = new System.Drawing.Size(609, 53);
-            this.panel_invoiceExternalCosts.TabIndex = 8;
+            panel_invoiceExternalCosts.Controls.Add(label_invoiceExternalCosts);
+            panel_invoiceExternalCosts.Controls.Add(button_invoiceExternalCosts);
+            panel_invoiceExternalCosts.Location = new System.Drawing.Point(3, 1311);
+            panel_invoiceExternalCosts.Name = "panel_invoiceExternalCosts";
+            panel_invoiceExternalCosts.Size = new System.Drawing.Size(426, 32);
+            panel_invoiceExternalCosts.TabIndex = 8;
             // 
             // label_invoiceExternalCosts
             // 
-            this.label_invoiceExternalCosts.AutoSize = true;
-            this.label_invoiceExternalCosts.ForeColor = System.Drawing.Color.Black;
-            this.label_invoiceExternalCosts.Location = new System.Drawing.Point(64, 13);
-            this.label_invoiceExternalCosts.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_invoiceExternalCosts.Name = "label_invoiceExternalCosts";
-            this.label_invoiceExternalCosts.Size = new System.Drawing.Size(248, 17);
-            this.label_invoiceExternalCosts.TabIndex = 1;
-            this.label_invoiceExternalCosts.Text = "Finance - Re-Invoicing of External Costs";
+            label_invoiceExternalCosts.AutoSize = true;
+            label_invoiceExternalCosts.ForeColor = System.Drawing.Color.Black;
+            label_invoiceExternalCosts.Location = new System.Drawing.Point(45, 8);
+            label_invoiceExternalCosts.Name = "label_invoiceExternalCosts";
+            label_invoiceExternalCosts.Size = new System.Drawing.Size(248, 17);
+            label_invoiceExternalCosts.TabIndex = 1;
+            label_invoiceExternalCosts.Text = "Finance - Re-Invoicing of External Costs";
             // 
             // button_invoiceExternalCosts
             // 
-            this.button_invoiceExternalCosts.BackColor = System.Drawing.Color.White;
-            this.button_invoiceExternalCosts.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button_invoiceExternalCosts.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_invoiceExternalCosts.FlatAppearance.BorderSize = 0;
-            this.button_invoiceExternalCosts.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_invoiceExternalCosts.Location = new System.Drawing.Point(13, 2);
-            this.button_invoiceExternalCosts.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_invoiceExternalCosts.Name = "button_invoiceExternalCosts";
-            this.button_invoiceExternalCosts.Size = new System.Drawing.Size(43, 50);
-            this.button_invoiceExternalCosts.TabIndex = 0;
-            this.button_invoiceExternalCosts.UseVisualStyleBackColor = false;
-            this.button_invoiceExternalCosts.Click += new System.EventHandler(this.button_expand_Click);
+            button_invoiceExternalCosts.BackColor = System.Drawing.Color.White;
+            button_invoiceExternalCosts.BackgroundImageLayout = ImageLayout.Stretch;
+            button_invoiceExternalCosts.Cursor = Cursors.Hand;
+            button_invoiceExternalCosts.FlatAppearance.BorderSize = 0;
+            button_invoiceExternalCosts.FlatStyle = FlatStyle.Flat;
+            button_invoiceExternalCosts.Location = new System.Drawing.Point(9, 1);
+            button_invoiceExternalCosts.Name = "button_invoiceExternalCosts";
+            button_invoiceExternalCosts.Size = new System.Drawing.Size(30, 30);
+            button_invoiceExternalCosts.TabIndex = 0;
+            button_invoiceExternalCosts.UseVisualStyleBackColor = false;
+            button_invoiceExternalCosts.Click += button_expand_Click;
             // 
             // panel_incoiceExternalCosts
             // 
-            this.panel_incoiceExternalCosts.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
-            this.panel_incoiceExternalCosts.Controls.Add(this.checkBox_defaultExpenseIsBillable);
-            this.panel_incoiceExternalCosts.Controls.Add(this.checkBox_defaultMileageIsBillable);
-            this.panel_incoiceExternalCosts.Controls.Add(this.label_defaultMileageDistance);
-            this.panel_incoiceExternalCosts.Controls.Add(this.label_defaultDistIsMaxBillable);
-            this.panel_incoiceExternalCosts.Controls.Add(this.label_expenseIsBillable);
-            this.panel_incoiceExternalCosts.Controls.Add(this.label_mileageIsBillable);
-            this.panel_incoiceExternalCosts.Controls.Add(this.comboBox_defaultDistIsMaxBillable);
-            this.panel_incoiceExternalCosts.Controls.Add(this.comboBox_defaultMileageDistance);
-            this.panel_incoiceExternalCosts.Controls.Add(this.comboBox_expenseIsBillable);
-            this.panel_incoiceExternalCosts.Controls.Add(this.comboBox_mileageIsBillable);
-            this.panel_incoiceExternalCosts.Location = new System.Drawing.Point(4, 2246);
-            this.panel_incoiceExternalCosts.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_incoiceExternalCosts.MaximumSize = new System.Drawing.Size(609, 235);
-            this.panel_incoiceExternalCosts.MinimumSize = new System.Drawing.Size(609, 0);
-            this.panel_incoiceExternalCosts.Name = "panel_incoiceExternalCosts";
-            this.panel_incoiceExternalCosts.Size = new System.Drawing.Size(609, 235);
-            this.panel_incoiceExternalCosts.TabIndex = 9;
+            panel_incoiceExternalCosts.BackColor = System.Drawing.Color.FromArgb(224, 224, 224);
+            panel_incoiceExternalCosts.Controls.Add(checkBox_defaultExpenseIsBillable);
+            panel_incoiceExternalCosts.Controls.Add(checkBox_defaultMileageIsBillable);
+            panel_incoiceExternalCosts.Controls.Add(label_defaultMileageDistance);
+            panel_incoiceExternalCosts.Controls.Add(label_defaultDistIsMaxBillable);
+            panel_incoiceExternalCosts.Controls.Add(label_expenseIsBillable);
+            panel_incoiceExternalCosts.Controls.Add(label_mileageIsBillable);
+            panel_incoiceExternalCosts.Controls.Add(comboBox_defaultDistIsMaxBillable);
+            panel_incoiceExternalCosts.Controls.Add(comboBox_defaultMileageDistance);
+            panel_incoiceExternalCosts.Controls.Add(comboBox_expenseIsBillable);
+            panel_incoiceExternalCosts.Controls.Add(comboBox_mileageIsBillable);
+            panel_incoiceExternalCosts.Location = new System.Drawing.Point(3, 1349);
+            panel_incoiceExternalCosts.MaximumSize = new System.Drawing.Size(426, 141);
+            panel_incoiceExternalCosts.MinimumSize = new System.Drawing.Size(426, 0);
+            panel_incoiceExternalCosts.Name = "panel_incoiceExternalCosts";
+            panel_incoiceExternalCosts.Size = new System.Drawing.Size(426, 141);
+            panel_incoiceExternalCosts.TabIndex = 9;
             // 
             // checkBox_defaultExpenseIsBillable
             // 
-            this.checkBox_defaultExpenseIsBillable.AutoSize = true;
-            this.checkBox_defaultExpenseIsBillable.Location = new System.Drawing.Point(487, 77);
-            this.checkBox_defaultExpenseIsBillable.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultExpenseIsBillable.Name = "checkBox_defaultExpenseIsBillable";
-            this.checkBox_defaultExpenseIsBillable.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultExpenseIsBillable.TabIndex = 5;
-            this.checkBox_defaultExpenseIsBillable.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultExpenseIsBillable, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultExpenseIsBillable.UseVisualStyleBackColor = true;
-            this.checkBox_defaultExpenseIsBillable.CheckedChanged += new System.EventHandler(this.checkBox_defaultExpenseIsBillable_CheckedChanged);
+            checkBox_defaultExpenseIsBillable.AutoSize = true;
+            checkBox_defaultExpenseIsBillable.Location = new System.Drawing.Point(341, 46);
+            checkBox_defaultExpenseIsBillable.Name = "checkBox_defaultExpenseIsBillable";
+            checkBox_defaultExpenseIsBillable.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultExpenseIsBillable.TabIndex = 5;
+            checkBox_defaultExpenseIsBillable.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultExpenseIsBillable, "Set default values for all rows of a particular column field");
+            checkBox_defaultExpenseIsBillable.UseVisualStyleBackColor = true;
+            checkBox_defaultExpenseIsBillable.CheckedChanged += checkBox_defaultExpenseIsBillable_CheckedChanged;
             // 
             // checkBox_defaultMileageIsBillable
             // 
-            this.checkBox_defaultMileageIsBillable.AutoSize = true;
-            this.checkBox_defaultMileageIsBillable.Location = new System.Drawing.Point(487, 127);
-            this.checkBox_defaultMileageIsBillable.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultMileageIsBillable.Name = "checkBox_defaultMileageIsBillable";
-            this.checkBox_defaultMileageIsBillable.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultMileageIsBillable.TabIndex = 4;
-            this.checkBox_defaultMileageIsBillable.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultMileageIsBillable, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultMileageIsBillable.UseVisualStyleBackColor = true;
-            this.checkBox_defaultMileageIsBillable.CheckedChanged += new System.EventHandler(this.checkBox_defaultMileageIsBillable_CheckedChanged);
+            checkBox_defaultMileageIsBillable.AutoSize = true;
+            checkBox_defaultMileageIsBillable.Location = new System.Drawing.Point(341, 76);
+            checkBox_defaultMileageIsBillable.Name = "checkBox_defaultMileageIsBillable";
+            checkBox_defaultMileageIsBillable.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultMileageIsBillable.TabIndex = 4;
+            checkBox_defaultMileageIsBillable.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultMileageIsBillable, "Set default values for all rows of a particular column field");
+            checkBox_defaultMileageIsBillable.UseVisualStyleBackColor = true;
+            checkBox_defaultMileageIsBillable.CheckedChanged += checkBox_defaultMileageIsBillable_CheckedChanged;
             // 
             // label_defaultMileageDistance
             // 
-            this.label_defaultMileageDistance.AutoSize = true;
-            this.label_defaultMileageDistance.Location = new System.Drawing.Point(14, 25);
-            this.label_defaultMileageDistance.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_defaultMileageDistance.Name = "label_defaultMileageDistance";
-            this.label_defaultMileageDistance.Size = new System.Drawing.Size(157, 17);
-            this.label_defaultMileageDistance.TabIndex = 1;
-            this.label_defaultMileageDistance.Text = "Default Mileage Distance";
+            label_defaultMileageDistance.AutoSize = true;
+            label_defaultMileageDistance.Location = new System.Drawing.Point(10, 15);
+            label_defaultMileageDistance.Name = "label_defaultMileageDistance";
+            label_defaultMileageDistance.Size = new System.Drawing.Size(157, 17);
+            label_defaultMileageDistance.TabIndex = 1;
+            label_defaultMileageDistance.Text = "Default Mileage Distance";
             // 
             // label_defaultDistIsMaxBillable
             // 
-            this.label_defaultDistIsMaxBillable.AutoSize = true;
-            this.label_defaultDistIsMaxBillable.Location = new System.Drawing.Point(14, 180);
-            this.label_defaultDistIsMaxBillable.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_defaultDistIsMaxBillable.Name = "label_defaultDistIsMaxBillable";
-            this.label_defaultDistIsMaxBillable.Size = new System.Drawing.Size(168, 17);
-            this.label_defaultDistIsMaxBillable.TabIndex = 1;
-            this.label_defaultDistIsMaxBillable.Text = "Default Dist Is Max Billable";
+            label_defaultDistIsMaxBillable.AutoSize = true;
+            label_defaultDistIsMaxBillable.Location = new System.Drawing.Point(10, 108);
+            label_defaultDistIsMaxBillable.Name = "label_defaultDistIsMaxBillable";
+            label_defaultDistIsMaxBillable.Size = new System.Drawing.Size(168, 17);
+            label_defaultDistIsMaxBillable.TabIndex = 1;
+            label_defaultDistIsMaxBillable.Text = "Default Dist Is Max Billable";
             // 
             // label_expenseIsBillable
             // 
-            this.label_expenseIsBillable.AutoSize = true;
-            this.label_expenseIsBillable.Location = new System.Drawing.Point(14, 77);
-            this.label_expenseIsBillable.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_expenseIsBillable.Name = "label_expenseIsBillable";
-            this.label_expenseIsBillable.Size = new System.Drawing.Size(118, 17);
-            this.label_expenseIsBillable.TabIndex = 1;
-            this.label_expenseIsBillable.Text = "Expense Is Billable";
+            label_expenseIsBillable.AutoSize = true;
+            label_expenseIsBillable.Location = new System.Drawing.Point(10, 46);
+            label_expenseIsBillable.Name = "label_expenseIsBillable";
+            label_expenseIsBillable.Size = new System.Drawing.Size(118, 17);
+            label_expenseIsBillable.TabIndex = 1;
+            label_expenseIsBillable.Text = "Expense Is Billable";
             // 
             // label_mileageIsBillable
             // 
-            this.label_mileageIsBillable.AutoSize = true;
-            this.label_mileageIsBillable.Location = new System.Drawing.Point(14, 128);
-            this.label_mileageIsBillable.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_mileageIsBillable.Name = "label_mileageIsBillable";
-            this.label_mileageIsBillable.Size = new System.Drawing.Size(115, 17);
-            this.label_mileageIsBillable.TabIndex = 1;
-            this.label_mileageIsBillable.Text = "Mileage Is Billable";
+            label_mileageIsBillable.AutoSize = true;
+            label_mileageIsBillable.Location = new System.Drawing.Point(10, 77);
+            label_mileageIsBillable.Name = "label_mileageIsBillable";
+            label_mileageIsBillable.Size = new System.Drawing.Size(115, 17);
+            label_mileageIsBillable.TabIndex = 1;
+            label_mileageIsBillable.Text = "Mileage Is Billable";
             // 
             // comboBox_defaultDistIsMaxBillable
             // 
-            this.comboBox_defaultDistIsMaxBillable.FormattingEnabled = true;
-            this.comboBox_defaultDistIsMaxBillable.Location = new System.Drawing.Point(266, 175);
-            this.comboBox_defaultDistIsMaxBillable.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_defaultDistIsMaxBillable.Name = "comboBox_defaultDistIsMaxBillable";
-            this.comboBox_defaultDistIsMaxBillable.Size = new System.Drawing.Size(257, 25);
-            this.comboBox_defaultDistIsMaxBillable.TabIndex = 3;
+            comboBox_defaultDistIsMaxBillable.FormattingEnabled = true;
+            comboBox_defaultDistIsMaxBillable.Location = new System.Drawing.Point(186, 105);
+            comboBox_defaultDistIsMaxBillable.Name = "comboBox_defaultDistIsMaxBillable";
+            comboBox_defaultDistIsMaxBillable.Size = new System.Drawing.Size(181, 25);
+            comboBox_defaultDistIsMaxBillable.TabIndex = 3;
             // 
             // comboBox_defaultMileageDistance
             // 
-            this.comboBox_defaultMileageDistance.FormattingEnabled = true;
-            this.comboBox_defaultMileageDistance.Location = new System.Drawing.Point(266, 20);
-            this.comboBox_defaultMileageDistance.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_defaultMileageDistance.Name = "comboBox_defaultMileageDistance";
-            this.comboBox_defaultMileageDistance.Size = new System.Drawing.Size(257, 25);
-            this.comboBox_defaultMileageDistance.TabIndex = 3;
+            comboBox_defaultMileageDistance.FormattingEnabled = true;
+            comboBox_defaultMileageDistance.Location = new System.Drawing.Point(186, 12);
+            comboBox_defaultMileageDistance.Name = "comboBox_defaultMileageDistance";
+            comboBox_defaultMileageDistance.Size = new System.Drawing.Size(181, 25);
+            comboBox_defaultMileageDistance.TabIndex = 3;
             // 
             // comboBox_expenseIsBillable
             // 
-            this.comboBox_expenseIsBillable.FormattingEnabled = true;
-            this.comboBox_expenseIsBillable.Location = new System.Drawing.Point(266, 72);
-            this.comboBox_expenseIsBillable.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_expenseIsBillable.Name = "comboBox_expenseIsBillable";
-            this.comboBox_expenseIsBillable.Size = new System.Drawing.Size(211, 25);
-            this.comboBox_expenseIsBillable.TabIndex = 3;
+            comboBox_expenseIsBillable.FormattingEnabled = true;
+            comboBox_expenseIsBillable.Location = new System.Drawing.Point(186, 43);
+            comboBox_expenseIsBillable.Name = "comboBox_expenseIsBillable";
+            comboBox_expenseIsBillable.Size = new System.Drawing.Size(149, 25);
+            comboBox_expenseIsBillable.TabIndex = 3;
             // 
             // comboBox_mileageIsBillable
             // 
-            this.comboBox_mileageIsBillable.FormattingEnabled = true;
-            this.comboBox_mileageIsBillable.Location = new System.Drawing.Point(266, 123);
-            this.comboBox_mileageIsBillable.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_mileageIsBillable.Name = "comboBox_mileageIsBillable";
-            this.comboBox_mileageIsBillable.Size = new System.Drawing.Size(211, 25);
-            this.comboBox_mileageIsBillable.TabIndex = 3;
+            comboBox_mileageIsBillable.FormattingEnabled = true;
+            comboBox_mileageIsBillable.Location = new System.Drawing.Point(186, 74);
+            comboBox_mileageIsBillable.Name = "comboBox_mileageIsBillable";
+            comboBox_mileageIsBillable.Size = new System.Drawing.Size(149, 25);
+            comboBox_mileageIsBillable.TabIndex = 3;
             // 
             // label_delimiter
             // 
-            this.label_delimiter.AutoSize = true;
-            this.label_delimiter.Location = new System.Drawing.Point(14, 125);
-            this.label_delimiter.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_delimiter.Name = "label_delimiter";
-            this.label_delimiter.Size = new System.Drawing.Size(62, 17);
-            this.label_delimiter.TabIndex = 1;
-            this.label_delimiter.Text = "Delimiter";
+            label_delimiter.AutoSize = true;
+            label_delimiter.Location = new System.Drawing.Point(10, 75);
+            label_delimiter.Name = "label_delimiter";
+            label_delimiter.Size = new System.Drawing.Size(62, 17);
+            label_delimiter.TabIndex = 1;
+            label_delimiter.Text = "Delimiter";
             // 
             // comboBox_delimiter
             // 
-            this.comboBox_delimiter.FormattingEnabled = true;
-            this.comboBox_delimiter.Location = new System.Drawing.Point(117, 120);
-            this.comboBox_delimiter.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_delimiter.Name = "comboBox_delimiter";
-            this.comboBox_delimiter.Size = new System.Drawing.Size(78, 25);
-            this.comboBox_delimiter.TabIndex = 7;
+            comboBox_delimiter.DropDownStyle = ComboBoxStyle.DropDownList;
+            comboBox_delimiter.FormattingEnabled = true;
+            comboBox_delimiter.Location = new System.Drawing.Point(82, 72);
+            comboBox_delimiter.Name = "comboBox_delimiter";
+            comboBox_delimiter.Size = new System.Drawing.Size(56, 25);
+            comboBox_delimiter.TabIndex = 7;
             // 
             // groupBox_customerMandatoryFields
             // 
-            this.groupBox_customerMandatoryFields.Controls.Add(this.checkBox_defaultCountryISO);
-            this.groupBox_customerMandatoryFields.Controls.Add(this.checkBox_defaultCustomerStatus);
-            this.groupBox_customerMandatoryFields.Controls.Add(this.checkBox_defaultCurrencyISO);
-            this.groupBox_customerMandatoryFields.Controls.Add(this.label_countryISO);
-            this.groupBox_customerMandatoryFields.Controls.Add(this.label_customerStatus);
-            this.groupBox_customerMandatoryFields.Controls.Add(this.comboBox_countryISO);
-            this.groupBox_customerMandatoryFields.Controls.Add(this.comboBox_customerStatus);
-            this.groupBox_customerMandatoryFields.Controls.Add(this.label_currencyISO);
-            this.groupBox_customerMandatoryFields.Controls.Add(this.comboBox_currencyISO);
-            this.groupBox_customerMandatoryFields.Controls.Add(this.label_customerName);
-            this.groupBox_customerMandatoryFields.Controls.Add(this.comboBox_customerName);
-            this.groupBox_customerMandatoryFields.Location = new System.Drawing.Point(241, 125);
-            this.groupBox_customerMandatoryFields.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.groupBox_customerMandatoryFields.Name = "groupBox_customerMandatoryFields";
-            this.groupBox_customerMandatoryFields.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.groupBox_customerMandatoryFields.Size = new System.Drawing.Size(500, 275);
-            this.groupBox_customerMandatoryFields.TabIndex = 5;
-            this.groupBox_customerMandatoryFields.TabStop = false;
-            this.groupBox_customerMandatoryFields.Text = "Mandatory";
+            groupBox_customerMandatoryFields.Controls.Add(checkBox_defaultCountryISO);
+            groupBox_customerMandatoryFields.Controls.Add(checkBox_defaultCustomerStatus);
+            groupBox_customerMandatoryFields.Controls.Add(checkBox_defaultCurrencyISO);
+            groupBox_customerMandatoryFields.Controls.Add(label_countryISO);
+            groupBox_customerMandatoryFields.Controls.Add(label_customerStatus);
+            groupBox_customerMandatoryFields.Controls.Add(comboBox_countryISO);
+            groupBox_customerMandatoryFields.Controls.Add(comboBox_customerStatus);
+            groupBox_customerMandatoryFields.Controls.Add(label_currencyISO);
+            groupBox_customerMandatoryFields.Controls.Add(comboBox_currencyISO);
+            groupBox_customerMandatoryFields.Controls.Add(label_customerName);
+            groupBox_customerMandatoryFields.Controls.Add(comboBox_customerName);
+            groupBox_customerMandatoryFields.Location = new System.Drawing.Point(169, 75);
+            groupBox_customerMandatoryFields.Name = "groupBox_customerMandatoryFields";
+            groupBox_customerMandatoryFields.Size = new System.Drawing.Size(350, 165);
+            groupBox_customerMandatoryFields.TabIndex = 5;
+            groupBox_customerMandatoryFields.TabStop = false;
+            groupBox_customerMandatoryFields.Text = "Mandatory";
             // 
             // checkBox_defaultCountryISO
             // 
-            this.checkBox_defaultCountryISO.AutoSize = true;
-            this.checkBox_defaultCountryISO.Location = new System.Drawing.Point(396, 205);
-            this.checkBox_defaultCountryISO.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultCountryISO.Name = "checkBox_defaultCountryISO";
-            this.checkBox_defaultCountryISO.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultCountryISO.TabIndex = 8;
-            this.checkBox_defaultCountryISO.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultCountryISO, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultCountryISO.UseVisualStyleBackColor = true;
-            this.checkBox_defaultCountryISO.CheckedChanged += new System.EventHandler(this.checkBox_defaultCountryISO_CheckedChanged);
+            checkBox_defaultCountryISO.AutoSize = true;
+            checkBox_defaultCountryISO.Location = new System.Drawing.Point(277, 123);
+            checkBox_defaultCountryISO.Name = "checkBox_defaultCountryISO";
+            checkBox_defaultCountryISO.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultCountryISO.TabIndex = 8;
+            checkBox_defaultCountryISO.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultCountryISO, "Set default values for all rows of a particular column field");
+            checkBox_defaultCountryISO.UseVisualStyleBackColor = true;
+            checkBox_defaultCountryISO.CheckedChanged += checkBox_defaultCountryISO_CheckedChanged;
             // 
             // checkBox_defaultCustomerStatus
             // 
-            this.checkBox_defaultCustomerStatus.AutoSize = true;
-            this.checkBox_defaultCustomerStatus.Location = new System.Drawing.Point(396, 153);
-            this.checkBox_defaultCustomerStatus.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultCustomerStatus.Name = "checkBox_defaultCustomerStatus";
-            this.checkBox_defaultCustomerStatus.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultCustomerStatus.TabIndex = 8;
-            this.checkBox_defaultCustomerStatus.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultCustomerStatus, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultCustomerStatus.UseVisualStyleBackColor = true;
-            this.checkBox_defaultCustomerStatus.CheckedChanged += new System.EventHandler(this.checkBox_defaultCustomerStatus_CheckedChanged);
+            checkBox_defaultCustomerStatus.AutoSize = true;
+            checkBox_defaultCustomerStatus.Location = new System.Drawing.Point(277, 92);
+            checkBox_defaultCustomerStatus.Name = "checkBox_defaultCustomerStatus";
+            checkBox_defaultCustomerStatus.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultCustomerStatus.TabIndex = 8;
+            checkBox_defaultCustomerStatus.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultCustomerStatus, "Set default values for all rows of a particular column field");
+            checkBox_defaultCustomerStatus.UseVisualStyleBackColor = true;
+            checkBox_defaultCustomerStatus.CheckedChanged += checkBox_defaultCustomerStatus_CheckedChanged;
             // 
             // checkBox_defaultCurrencyISO
             // 
-            this.checkBox_defaultCurrencyISO.AutoSize = true;
-            this.checkBox_defaultCurrencyISO.Location = new System.Drawing.Point(396, 105);
-            this.checkBox_defaultCurrencyISO.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultCurrencyISO.Name = "checkBox_defaultCurrencyISO";
-            this.checkBox_defaultCurrencyISO.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultCurrencyISO.TabIndex = 8;
-            this.checkBox_defaultCurrencyISO.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultCurrencyISO, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultCurrencyISO.UseVisualStyleBackColor = true;
-            this.checkBox_defaultCurrencyISO.CheckedChanged += new System.EventHandler(this.checkBox_defaultCurrencyISO_CheckedChanged);
+            checkBox_defaultCurrencyISO.AutoSize = true;
+            checkBox_defaultCurrencyISO.Location = new System.Drawing.Point(277, 63);
+            checkBox_defaultCurrencyISO.Name = "checkBox_defaultCurrencyISO";
+            checkBox_defaultCurrencyISO.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultCurrencyISO.TabIndex = 8;
+            checkBox_defaultCurrencyISO.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultCurrencyISO, "Set default values for all rows of a particular column field");
+            checkBox_defaultCurrencyISO.UseVisualStyleBackColor = true;
+            checkBox_defaultCurrencyISO.CheckedChanged += checkBox_defaultCurrencyISO_CheckedChanged;
             // 
             // label_countryISO
             // 
-            this.label_countryISO.AutoSize = true;
-            this.label_countryISO.Location = new System.Drawing.Point(9, 207);
-            this.label_countryISO.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_countryISO.Name = "label_countryISO";
-            this.label_countryISO.Size = new System.Drawing.Size(83, 17);
-            this.label_countryISO.TabIndex = 5;
-            this.label_countryISO.Text = "Country ISO";
+            label_countryISO.AutoSize = true;
+            label_countryISO.Location = new System.Drawing.Point(6, 124);
+            label_countryISO.Name = "label_countryISO";
+            label_countryISO.Size = new System.Drawing.Size(83, 17);
+            label_countryISO.TabIndex = 5;
+            label_countryISO.Text = "Country ISO";
             // 
             // label_customerStatus
             // 
-            this.label_customerStatus.AutoSize = true;
-            this.label_customerStatus.Location = new System.Drawing.Point(7, 155);
-            this.label_customerStatus.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_customerStatus.Name = "label_customerStatus";
-            this.label_customerStatus.Size = new System.Drawing.Size(109, 17);
-            this.label_customerStatus.TabIndex = 5;
-            this.label_customerStatus.Text = "Customer Status";
+            label_customerStatus.AutoSize = true;
+            label_customerStatus.Location = new System.Drawing.Point(5, 93);
+            label_customerStatus.Name = "label_customerStatus";
+            label_customerStatus.Size = new System.Drawing.Size(109, 17);
+            label_customerStatus.TabIndex = 5;
+            label_customerStatus.Text = "Customer Status";
             // 
             // comboBox_countryISO
             // 
-            this.comboBox_countryISO.FormattingEnabled = true;
-            this.comboBox_countryISO.Location = new System.Drawing.Point(197, 202);
-            this.comboBox_countryISO.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_countryISO.Name = "comboBox_countryISO";
-            this.comboBox_countryISO.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_countryISO.TabIndex = 7;
+            comboBox_countryISO.FormattingEnabled = true;
+            comboBox_countryISO.Location = new System.Drawing.Point(138, 121);
+            comboBox_countryISO.Name = "comboBox_countryISO";
+            comboBox_countryISO.Size = new System.Drawing.Size(133, 25);
+            comboBox_countryISO.TabIndex = 7;
             // 
             // comboBox_customerStatus
             // 
-            this.comboBox_customerStatus.FormattingEnabled = true;
-            this.comboBox_customerStatus.Location = new System.Drawing.Point(197, 150);
-            this.comboBox_customerStatus.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_customerStatus.Name = "comboBox_customerStatus";
-            this.comboBox_customerStatus.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_customerStatus.TabIndex = 6;
+            comboBox_customerStatus.FormattingEnabled = true;
+            comboBox_customerStatus.Location = new System.Drawing.Point(138, 90);
+            comboBox_customerStatus.Name = "comboBox_customerStatus";
+            comboBox_customerStatus.Size = new System.Drawing.Size(133, 25);
+            comboBox_customerStatus.TabIndex = 6;
             // 
             // label_currencyISO
             // 
-            this.label_currencyISO.AutoSize = true;
-            this.label_currencyISO.Location = new System.Drawing.Point(9, 103);
-            this.label_currencyISO.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_currencyISO.Name = "label_currencyISO";
-            this.label_currencyISO.Size = new System.Drawing.Size(87, 17);
-            this.label_currencyISO.TabIndex = 5;
-            this.label_currencyISO.Text = "Currency ISO";
+            label_currencyISO.AutoSize = true;
+            label_currencyISO.Location = new System.Drawing.Point(6, 62);
+            label_currencyISO.Name = "label_currencyISO";
+            label_currencyISO.Size = new System.Drawing.Size(87, 17);
+            label_currencyISO.TabIndex = 5;
+            label_currencyISO.Text = "Currency ISO";
             // 
             // comboBox_currencyISO
             // 
-            this.comboBox_currencyISO.FormattingEnabled = true;
-            this.comboBox_currencyISO.Location = new System.Drawing.Point(197, 98);
-            this.comboBox_currencyISO.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_currencyISO.Name = "comboBox_currencyISO";
-            this.comboBox_currencyISO.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_currencyISO.TabIndex = 4;
+            comboBox_currencyISO.FormattingEnabled = true;
+            comboBox_currencyISO.Location = new System.Drawing.Point(138, 59);
+            comboBox_currencyISO.Name = "comboBox_currencyISO";
+            comboBox_currencyISO.Size = new System.Drawing.Size(133, 25);
+            comboBox_currencyISO.TabIndex = 4;
             // 
             // label_customerName
             // 
-            this.label_customerName.AutoSize = true;
-            this.label_customerName.Location = new System.Drawing.Point(9, 52);
-            this.label_customerName.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_customerName.Name = "label_customerName";
-            this.label_customerName.Size = new System.Drawing.Size(107, 17);
-            this.label_customerName.TabIndex = 1;
-            this.label_customerName.Text = "Customer Name";
+            label_customerName.AutoSize = true;
+            label_customerName.Location = new System.Drawing.Point(6, 31);
+            label_customerName.Name = "label_customerName";
+            label_customerName.Size = new System.Drawing.Size(107, 17);
+            label_customerName.TabIndex = 1;
+            label_customerName.Text = "Customer Name";
             // 
             // comboBox_customerName
             // 
-            this.comboBox_customerName.FormattingEnabled = true;
-            this.comboBox_customerName.Location = new System.Drawing.Point(197, 47);
-            this.comboBox_customerName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_customerName.Name = "comboBox_customerName";
-            this.comboBox_customerName.Size = new System.Drawing.Size(188, 25);
-            this.comboBox_customerName.TabIndex = 3;
+            comboBox_customerName.FormattingEnabled = true;
+            comboBox_customerName.Location = new System.Drawing.Point(138, 28);
+            comboBox_customerName.Name = "comboBox_customerName";
+            comboBox_customerName.Size = new System.Drawing.Size(133, 25);
+            comboBox_customerName.TabIndex = 3;
             // 
             // label_customerSetup
             // 
-            this.label_customerSetup.AutoSize = true;
-            this.label_customerSetup.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.label_customerSetup.Location = new System.Drawing.Point(9, 27);
-            this.label_customerSetup.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_customerSetup.Name = "label_customerSetup";
-            this.label_customerSetup.Size = new System.Drawing.Size(260, 32);
-            this.label_customerSetup.TabIndex = 0;
-            this.label_customerSetup.Text = "Customer Data Import";
+            label_customerSetup.AutoSize = true;
+            label_customerSetup.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold);
+            label_customerSetup.Location = new System.Drawing.Point(6, 16);
+            label_customerSetup.Name = "label_customerSetup";
+            label_customerSetup.Size = new System.Drawing.Size(260, 32);
+            label_customerSetup.TabIndex = 0;
+            label_customerSetup.Text = "Customer Data Import";
             // 
             // button_customerSelectFile
             // 
-            this.button_customerSelectFile.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(43)))), ((int)(((byte)(141)))));
-            this.button_customerSelectFile.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_customerSelectFile.FlatAppearance.BorderSize = 0;
-            this.button_customerSelectFile.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_customerSelectFile.ForeColor = System.Drawing.Color.White;
-            this.button_customerSelectFile.Location = new System.Drawing.Point(19, 185);
-            this.button_customerSelectFile.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_customerSelectFile.Name = "button_customerSelectFile";
-            this.button_customerSelectFile.Size = new System.Drawing.Size(114, 48);
-            this.button_customerSelectFile.TabIndex = 4;
-            this.button_customerSelectFile.Text = "Select File";
-            this.defaultToolTip.SetToolTip(this.button_customerSelectFile, "Select input CSV file");
-            this.button_customerSelectFile.UseVisualStyleBackColor = false;
-            this.button_customerSelectFile.Click += new System.EventHandler(this.button_select_customer_file_Click);
+            button_customerSelectFile.BackColor = System.Drawing.Color.FromArgb(226, 43, 141);
+            button_customerSelectFile.Cursor = Cursors.Hand;
+            button_customerSelectFile.FlatAppearance.BorderSize = 0;
+            button_customerSelectFile.FlatStyle = FlatStyle.Flat;
+            button_customerSelectFile.ForeColor = System.Drawing.Color.White;
+            button_customerSelectFile.Location = new System.Drawing.Point(13, 111);
+            button_customerSelectFile.Name = "button_customerSelectFile";
+            button_customerSelectFile.Size = new System.Drawing.Size(80, 29);
+            button_customerSelectFile.TabIndex = 4;
+            button_customerSelectFile.Text = "Select File";
+            defaultToolTip.SetToolTip(button_customerSelectFile, "Select input CSV file");
+            button_customerSelectFile.UseVisualStyleBackColor = false;
+            button_customerSelectFile.Click += button_select_customer_file_Click;
             // 
             // defaultToolTip
             // 
-            this.defaultToolTip.ShowAlways = true;
+            defaultToolTip.ShowAlways = true;
             // 
             // tmrExpand
             // 
-            this.tmrExpand.Interval = 10;
-            this.tmrExpand.Tick += new System.EventHandler(this.tmrExpand_Tick);
+            tmrExpand.Interval = 10;
+            tmrExpand.Tick += tmrExpand_Tick;
             // 
             // label1
             // 
-            this.label1.AutoSize = true;
-            this.label1.ForeColor = System.Drawing.Color.Black;
-            this.label1.Location = new System.Drawing.Point(45, 8);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(138, 25);
-            this.label1.TabIndex = 1;
-            this.label1.Text = "Invoice Address";
+            label1.AutoSize = true;
+            label1.ForeColor = System.Drawing.Color.Black;
+            label1.Location = new System.Drawing.Point(45, 8);
+            label1.Name = "label1";
+            label1.Size = new System.Drawing.Size(90, 15);
+            label1.TabIndex = 1;
+            label1.Text = "Invoice Address";
             // 
             // button1
             // 
-            this.button1.BackColor = System.Drawing.Color.White;
-            this.button1.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button1.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button1.Location = new System.Drawing.Point(9, 1);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(30, 30);
-            this.button1.TabIndex = 0;
-            this.button1.UseVisualStyleBackColor = false;
+            button1.BackColor = System.Drawing.Color.White;
+            button1.BackgroundImageLayout = ImageLayout.Stretch;
+            button1.FlatStyle = FlatStyle.Flat;
+            button1.Location = new System.Drawing.Point(9, 1);
+            button1.Name = "button1";
+            button1.Size = new System.Drawing.Size(30, 30);
+            button1.TabIndex = 0;
+            button1.UseVisualStyleBackColor = false;
             // 
             // panel1
             // 
-            this.panel1.Controls.Add(this.label1);
-            this.panel1.Controls.Add(this.button1);
-            this.panel1.Location = new System.Drawing.Point(3, 3);
-            this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(438, 32);
-            this.panel1.TabIndex = 2;
+            panel1.Controls.Add(label1);
+            panel1.Controls.Add(button1);
+            panel1.Location = new System.Drawing.Point(3, 3);
+            panel1.Name = "panel1";
+            panel1.Size = new System.Drawing.Size(438, 32);
+            panel1.TabIndex = 2;
             // 
             // UserControl_CustomerImport
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.panel_customerFieldMapping);
-            this.Controls.Add(this.panel_customerButtons);
-            this.Controls.Add(this.panel_customerMessage);
-            this.Controls.Add(this.panel_customerDataTable);
-            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.Name = "UserControl_CustomerImport";
-            this.Size = new System.Drawing.Size(1437, 1070);
-            this.Load += new System.EventHandler(this.UserControl1_Load);
-            this.panel_customerDataTable.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridView_customer)).EndInit();
-            this.panel_customerMessage.ResumeLayout(false);
-            this.panel_customerMessage.PerformLayout();
-            this.panel_customerButtons.ResumeLayout(false);
-            this.panel_customerFieldMapping.ResumeLayout(false);
-            this.panel_customerFieldMapping.PerformLayout();
-            this.flowLayoutPanel_NonMandatoryFields.ResumeLayout(false);
-            this.panel_customerDetailsButton.ResumeLayout(false);
-            this.panel_customerDetailsButton.PerformLayout();
-            this.panel_customerDetails.ResumeLayout(false);
-            this.panel_customerDetails.PerformLayout();
-            this.panel_contactDetailsButton.ResumeLayout(false);
-            this.panel_contactDetailsButton.PerformLayout();
-            this.panel_contactDetails.ResumeLayout(false);
-            this.panel_contactDetails.PerformLayout();
-            this.panel_invoiceAddressButton.ResumeLayout(false);
-            this.panel_invoiceAddressButton.PerformLayout();
-            this.panel_invoiceAddress.ResumeLayout(false);
-            this.panel_invoiceAddress.PerformLayout();
-            this.panel2.ResumeLayout(false);
-            this.panel2.PerformLayout();
-            this.panel_financeCompanyInfo.ResumeLayout(false);
-            this.panel_financeCompanyInfo.PerformLayout();
-            this.panel_defaultInvoiceSettingsButton.ResumeLayout(false);
-            this.panel_defaultInvoiceSettingsButton.PerformLayout();
-            this.panel_defaultInvoiceSettings.ResumeLayout(false);
-            this.panel_defaultInvoiceSettings.PerformLayout();
-            this.panel_invoiceExternalCosts.ResumeLayout(false);
-            this.panel_invoiceExternalCosts.PerformLayout();
-            this.panel_incoiceExternalCosts.ResumeLayout(false);
-            this.panel_incoiceExternalCosts.PerformLayout();
-            this.groupBox_customerMandatoryFields.ResumeLayout(false);
-            this.groupBox_customerMandatoryFields.PerformLayout();
-            this.panel1.ResumeLayout(false);
-            this.panel1.PerformLayout();
-            this.ResumeLayout(false);
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            Controls.Add(panel_customerFieldMapping);
+            Controls.Add(panel_customerButtons);
+            Controls.Add(panel_customerMessage);
+            Controls.Add(panel_customerDataTable);
+            Name = "UserControl_CustomerImport";
+            Size = new System.Drawing.Size(1006, 642);
+            Load += UserControl1_Load;
+            panel_customerDataTable.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)dataGridView_customer).EndInit();
+            panel_customerMessage.ResumeLayout(false);
+            panel_customerMessage.PerformLayout();
+            panel_customerButtons.ResumeLayout(false);
+            panel_customerFieldMapping.ResumeLayout(false);
+            panel_customerFieldMapping.PerformLayout();
+            flowLayoutPanel_NonMandatoryFields.ResumeLayout(false);
+            panel_customerDetailsButton.ResumeLayout(false);
+            panel_customerDetailsButton.PerformLayout();
+            panel_customerDetails.ResumeLayout(false);
+            panel_customerDetails.PerformLayout();
+            panel_contactDetailsButton.ResumeLayout(false);
+            panel_contactDetailsButton.PerformLayout();
+            panel_contactDetails.ResumeLayout(false);
+            panel_contactDetails.PerformLayout();
+            panel_invoiceAddressButton.ResumeLayout(false);
+            panel_invoiceAddressButton.PerformLayout();
+            panel_invoiceAddress.ResumeLayout(false);
+            panel_invoiceAddress.PerformLayout();
+            panel2.ResumeLayout(false);
+            panel2.PerformLayout();
+            panel_financeCompanyInfo.ResumeLayout(false);
+            panel_financeCompanyInfo.PerformLayout();
+            panel_defaultInvoiceSettingsButton.ResumeLayout(false);
+            panel_defaultInvoiceSettingsButton.PerformLayout();
+            panel_defaultInvoiceSettings.ResumeLayout(false);
+            panel_defaultInvoiceSettings.PerformLayout();
+            panel_invoiceExternalCosts.ResumeLayout(false);
+            panel_invoiceExternalCosts.PerformLayout();
+            panel_incoiceExternalCosts.ResumeLayout(false);
+            panel_incoiceExternalCosts.PerformLayout();
+            groupBox_customerMandatoryFields.ResumeLayout(false);
+            groupBox_customerMandatoryFields.PerformLayout();
+            panel1.ResumeLayout(false);
+            panel1.PerformLayout();
+            ResumeLayout(false);
 
         }
 

--- a/UserControls/UserControl_CustomerImport.resx
+++ b/UserControls/UserControl_CustomerImport.resx
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema 
+    Microsoft ResX Schema
 
     Version 2.0
 
@@ -18,7 +18,7 @@
     <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
     <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
     <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing"">Blue</data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
     <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
         <value>[base64 mime encoded serialized .NET Framework object]</value>
     </data>
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter

--- a/UserControls/UserControl_EmployeeImport.Designer.cs
+++ b/UserControls/UserControl_EmployeeImport.Designer.cs
@@ -426,6 +426,7 @@
             // 
             // comboBox_delimiter
             // 
+            comboBox_delimiter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             comboBox_delimiter.FormattingEnabled = true;
             comboBox_delimiter.Location = new System.Drawing.Point(82, 72);
             comboBox_delimiter.Name = "comboBox_delimiter";

--- a/UserControls/UserControl_HourlyRateImport.Designer.cs
+++ b/UserControls/UserControl_HourlyRateImport.Designer.cs
@@ -313,6 +313,7 @@
             // 
             // comboBox_delimiter
             // 
+            comboBox_delimiter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             comboBox_delimiter.FormattingEnabled = true;
             comboBox_delimiter.Location = new System.Drawing.Point(82, 72);
             comboBox_delimiter.Name = "comboBox_delimiter";

--- a/UserControls/UserControl_PaymentImport.Designer.cs
+++ b/UserControls/UserControl_PaymentImport.Designer.cs
@@ -423,6 +423,7 @@
             // 
             // comboBox_delimiter
             // 
+            comboBox_delimiter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             comboBox_delimiter.FormattingEnabled = true;
             comboBox_delimiter.Location = new System.Drawing.Point(82, 72);
             comboBox_delimiter.Name = "comboBox_delimiter";

--- a/UserControls/UserControl_ProjectExpenseImport.Designer.cs
+++ b/UserControls/UserControl_ProjectExpenseImport.Designer.cs
@@ -28,813 +28,753 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            this.WorkerFetcher = new System.ComponentModel.BackgroundWorker();
-            this.panel_employeeDataTable = new System.Windows.Forms.Panel();
-            this.dataGridView_projectExpense = new System.Windows.Forms.DataGridView();
-            this.panel_projectMessage = new System.Windows.Forms.Panel();
-            this.textBox_projectExpenseImportMessages = new System.Windows.Forms.TextBox();
-            this.panel_projectExpenseButtons = new System.Windows.Forms.Panel();
-            this.button_clear = new System.Windows.Forms.Button();
-            this.button_import = new System.Windows.Forms.Button();
-            this.button_validate = new System.Windows.Forms.Button();
-            this.button_stop = new System.Windows.Forms.Button();
-            this.panel_projectExpenseFieldMapping = new System.Windows.Forms.Panel();
-            this.flowLayoutPanel_nonMandatoryFields = new System.Windows.Forms.FlowLayoutPanel();
-            this.panel_NonMandatoryButton = new System.Windows.Forms.Panel();
-            this.label_nonMandatoryFields = new System.Windows.Forms.Label();
-            this.button_expandNonMandatory = new System.Windows.Forms.Button();
-            this.panel_NonMandatoryFields = new System.Windows.Forms.Panel();
-            this.comboBox_profitRatio = new System.Windows.Forms.ComboBox();
-            this.label_profitRatio = new System.Windows.Forms.Label();
-            this.label_externalID = new System.Windows.Forms.Label();
-            this.comboBox_externalID = new System.Windows.Forms.ComboBox();
-            this.label_supplierInvoiceNo = new System.Windows.Forms.Label();
-            this.comboBox_supplierInvoiceNo = new System.Windows.Forms.ComboBox();
-            this.comboBox_comment = new System.Windows.Forms.ComboBox();
-            this.label_comment = new System.Windows.Forms.Label();
-            this.label_supplierNo = new System.Windows.Forms.Label();
-            this.comboBox_supplierNo = new System.Windows.Forms.ComboBox();
-            this.label_delimiter = new System.Windows.Forms.Label();
-            this.comboBox_delimiter = new System.Windows.Forms.ComboBox();
-            this.groupBox_projectExpenseMandatoryFields = new System.Windows.Forms.GroupBox();
-            this.checkBox_defaultIsBillable = new System.Windows.Forms.CheckBox();
-            this.checkBox_defaultExpenseCurrencyISO = new System.Windows.Forms.CheckBox();
-            this.comboBox_contractName = new System.Windows.Forms.ComboBox();
-            this.comboBox_expenseCurrencyISO = new System.Windows.Forms.ComboBox();
-            this.comboBox_VATAmount = new System.Windows.Forms.ComboBox();
-            this.comboBox_expenseNo = new System.Windows.Forms.ComboBox();
-            this.label_contractName = new System.Windows.Forms.Label();
-            this.label_expenseCurrencyISO = new System.Windows.Forms.Label();
-            this.label_VATAmountCurrency = new System.Windows.Forms.Label();
-            this.label_expenseNo = new System.Windows.Forms.Label();
-            this.checkBox_defaultExpenseType = new System.Windows.Forms.CheckBox();
-            this.checkBox_defaultPaymentMethod = new System.Windows.Forms.CheckBox();
-            this.label_salesPriceAmount = new System.Windows.Forms.Label();
-            this.comboBox_salesPriceAmount = new System.Windows.Forms.ComboBox();
-            this.comboBox_exchangeRate = new System.Windows.Forms.ComboBox();
-            this.label_amountIncludingVAT = new System.Windows.Forms.Label();
-            this.label_isBillable = new System.Windows.Forms.Label();
-            this.label_exchangeRate = new System.Windows.Forms.Label();
-            this.comboBox_amountIncludingVAT = new System.Windows.Forms.ComboBox();
-            this.label_expenseType = new System.Windows.Forms.Label();
-            this.comboBox_expenseType = new System.Windows.Forms.ComboBox();
-            this.label_paymentMethod = new System.Windows.Forms.Label();
-            this.comboBox_isBillable = new System.Windows.Forms.ComboBox();
-            this.comboBox_paymentMethod = new System.Windows.Forms.ComboBox();
-            this.label_purchaseDate = new System.Windows.Forms.Label();
-            this.comboBox_purchaseDate = new System.Windows.Forms.ComboBox();
-            this.label_projectNo = new System.Windows.Forms.Label();
-            this.comboBox_projectNo = new System.Windows.Forms.ComboBox();
-            this.label_projectExpenseSetup = new System.Windows.Forms.Label();
-            this.button_projectExpenseSelectFile = new System.Windows.Forms.Button();
-            this.tmrExpand = new System.Windows.Forms.Timer(this.components);
-            this.defaultToolTip = new System.Windows.Forms.ToolTip(this.components);
-            this.panel_employeeDataTable.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridView_projectExpense)).BeginInit();
-            this.panel_projectMessage.SuspendLayout();
-            this.panel_projectExpenseButtons.SuspendLayout();
-            this.panel_projectExpenseFieldMapping.SuspendLayout();
-            this.flowLayoutPanel_nonMandatoryFields.SuspendLayout();
-            this.panel_NonMandatoryButton.SuspendLayout();
-            this.panel_NonMandatoryFields.SuspendLayout();
-            this.groupBox_projectExpenseMandatoryFields.SuspendLayout();
-            this.SuspendLayout();
+            components = new System.ComponentModel.Container();
+            WorkerFetcher = new System.ComponentModel.BackgroundWorker();
+            panel_employeeDataTable = new System.Windows.Forms.Panel();
+            dataGridView_projectExpense = new System.Windows.Forms.DataGridView();
+            panel_projectMessage = new System.Windows.Forms.Panel();
+            textBox_projectExpenseImportMessages = new System.Windows.Forms.TextBox();
+            panel_projectExpenseButtons = new System.Windows.Forms.Panel();
+            button_clear = new System.Windows.Forms.Button();
+            button_import = new System.Windows.Forms.Button();
+            button_validate = new System.Windows.Forms.Button();
+            button_stop = new System.Windows.Forms.Button();
+            panel_projectExpenseFieldMapping = new System.Windows.Forms.Panel();
+            flowLayoutPanel_nonMandatoryFields = new System.Windows.Forms.FlowLayoutPanel();
+            panel_NonMandatoryButton = new System.Windows.Forms.Panel();
+            label_nonMandatoryFields = new System.Windows.Forms.Label();
+            button_expandNonMandatory = new System.Windows.Forms.Button();
+            panel_NonMandatoryFields = new System.Windows.Forms.Panel();
+            comboBox_profitRatio = new System.Windows.Forms.ComboBox();
+            label_profitRatio = new System.Windows.Forms.Label();
+            label_externalID = new System.Windows.Forms.Label();
+            comboBox_externalID = new System.Windows.Forms.ComboBox();
+            label_supplierInvoiceNo = new System.Windows.Forms.Label();
+            comboBox_supplierInvoiceNo = new System.Windows.Forms.ComboBox();
+            comboBox_comment = new System.Windows.Forms.ComboBox();
+            label_comment = new System.Windows.Forms.Label();
+            label_supplierNo = new System.Windows.Forms.Label();
+            comboBox_supplierNo = new System.Windows.Forms.ComboBox();
+            label_delimiter = new System.Windows.Forms.Label();
+            comboBox_delimiter = new System.Windows.Forms.ComboBox();
+            groupBox_projectExpenseMandatoryFields = new System.Windows.Forms.GroupBox();
+            checkBox_defaultIsBillable = new System.Windows.Forms.CheckBox();
+            checkBox_defaultExpenseCurrencyISO = new System.Windows.Forms.CheckBox();
+            comboBox_contractName = new System.Windows.Forms.ComboBox();
+            comboBox_expenseCurrencyISO = new System.Windows.Forms.ComboBox();
+            comboBox_VATAmount = new System.Windows.Forms.ComboBox();
+            comboBox_expenseNo = new System.Windows.Forms.ComboBox();
+            label_contractName = new System.Windows.Forms.Label();
+            label_expenseCurrencyISO = new System.Windows.Forms.Label();
+            label_VATAmountCurrency = new System.Windows.Forms.Label();
+            label_expenseNo = new System.Windows.Forms.Label();
+            checkBox_defaultExpenseType = new System.Windows.Forms.CheckBox();
+            checkBox_defaultPaymentMethod = new System.Windows.Forms.CheckBox();
+            label_salesPriceAmount = new System.Windows.Forms.Label();
+            comboBox_salesPriceAmount = new System.Windows.Forms.ComboBox();
+            comboBox_exchangeRate = new System.Windows.Forms.ComboBox();
+            label_amountIncludingVAT = new System.Windows.Forms.Label();
+            label_isBillable = new System.Windows.Forms.Label();
+            label_exchangeRate = new System.Windows.Forms.Label();
+            comboBox_amountIncludingVAT = new System.Windows.Forms.ComboBox();
+            label_expenseType = new System.Windows.Forms.Label();
+            comboBox_expenseType = new System.Windows.Forms.ComboBox();
+            label_paymentMethod = new System.Windows.Forms.Label();
+            comboBox_isBillable = new System.Windows.Forms.ComboBox();
+            comboBox_paymentMethod = new System.Windows.Forms.ComboBox();
+            label_purchaseDate = new System.Windows.Forms.Label();
+            comboBox_purchaseDate = new System.Windows.Forms.ComboBox();
+            label_projectNo = new System.Windows.Forms.Label();
+            comboBox_projectNo = new System.Windows.Forms.ComboBox();
+            label_projectExpenseSetup = new System.Windows.Forms.Label();
+            button_projectExpenseSelectFile = new System.Windows.Forms.Button();
+            tmrExpand = new System.Windows.Forms.Timer(components);
+            defaultToolTip = new System.Windows.Forms.ToolTip(components);
+            panel_employeeDataTable.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)dataGridView_projectExpense).BeginInit();
+            panel_projectMessage.SuspendLayout();
+            panel_projectExpenseButtons.SuspendLayout();
+            panel_projectExpenseFieldMapping.SuspendLayout();
+            flowLayoutPanel_nonMandatoryFields.SuspendLayout();
+            panel_NonMandatoryButton.SuspendLayout();
+            panel_NonMandatoryFields.SuspendLayout();
+            groupBox_projectExpenseMandatoryFields.SuspendLayout();
+            SuspendLayout();
             // 
             // WorkerFetcher
             // 
-            this.WorkerFetcher.WorkerReportsProgress = true;
-            this.WorkerFetcher.WorkerSupportsCancellation = true;
-            this.WorkerFetcher.DoWork += new System.ComponentModel.DoWorkEventHandler(this.WorkerFetcherDoWork);
+            WorkerFetcher.WorkerReportsProgress = true;
+            WorkerFetcher.WorkerSupportsCancellation = true;
+            WorkerFetcher.DoWork += WorkerFetcherDoWork;
             // 
             // panel_employeeDataTable
             // 
-            this.panel_employeeDataTable.Controls.Add(this.dataGridView_projectExpense);
-            this.panel_employeeDataTable.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel_employeeDataTable.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.panel_employeeDataTable.Location = new System.Drawing.Point(0, 770);
-            this.panel_employeeDataTable.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_employeeDataTable.Name = "panel_employeeDataTable";
-            this.panel_employeeDataTable.Size = new System.Drawing.Size(1437, 300);
-            this.panel_employeeDataTable.TabIndex = 6;
+            panel_employeeDataTable.Controls.Add(dataGridView_projectExpense);
+            panel_employeeDataTable.Dock = System.Windows.Forms.DockStyle.Bottom;
+            panel_employeeDataTable.ForeColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            panel_employeeDataTable.Location = new System.Drawing.Point(0, 462);
+            panel_employeeDataTable.Name = "panel_employeeDataTable";
+            panel_employeeDataTable.Size = new System.Drawing.Size(1006, 180);
+            panel_employeeDataTable.TabIndex = 6;
             // 
             // dataGridView_projectExpense
             // 
-            this.dataGridView_projectExpense.BackgroundColor = System.Drawing.Color.DarkGray;
-            this.dataGridView_projectExpense.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.dataGridView_projectExpense.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dataGridView_projectExpense.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.dataGridView_projectExpense.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.dataGridView_projectExpense.Location = new System.Drawing.Point(0, 0);
-            this.dataGridView_projectExpense.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.dataGridView_projectExpense.Name = "dataGridView_projectExpense";
-            this.dataGridView_projectExpense.Size = new System.Drawing.Size(1437, 300);
-            this.dataGridView_projectExpense.TabIndex = 0;
+            dataGridView_projectExpense.BackgroundColor = System.Drawing.Color.DarkGray;
+            dataGridView_projectExpense.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            dataGridView_projectExpense.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            dataGridView_projectExpense.Dock = System.Windows.Forms.DockStyle.Bottom;
+            dataGridView_projectExpense.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold);
+            dataGridView_projectExpense.Location = new System.Drawing.Point(0, 0);
+            dataGridView_projectExpense.Name = "dataGridView_projectExpense";
+            dataGridView_projectExpense.Size = new System.Drawing.Size(1006, 180);
+            dataGridView_projectExpense.TabIndex = 0;
             // 
             // panel_projectMessage
             // 
-            this.panel_projectMessage.Controls.Add(this.textBox_projectExpenseImportMessages);
-            this.panel_projectMessage.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel_projectMessage.Location = new System.Drawing.Point(0, 463);
-            this.panel_projectMessage.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_projectMessage.Name = "panel_projectMessage";
-            this.panel_projectMessage.Size = new System.Drawing.Size(1437, 307);
-            this.panel_projectMessage.TabIndex = 10;
+            panel_projectMessage.Controls.Add(textBox_projectExpenseImportMessages);
+            panel_projectMessage.Dock = System.Windows.Forms.DockStyle.Bottom;
+            panel_projectMessage.Location = new System.Drawing.Point(0, 278);
+            panel_projectMessage.Name = "panel_projectMessage";
+            panel_projectMessage.Size = new System.Drawing.Size(1006, 184);
+            panel_projectMessage.TabIndex = 10;
             // 
             // textBox_projectExpenseImportMessages
             // 
-            this.textBox_projectExpenseImportMessages.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
-            this.textBox_projectExpenseImportMessages.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.textBox_projectExpenseImportMessages.Cursor = System.Windows.Forms.Cursors.Default;
-            this.textBox_projectExpenseImportMessages.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.textBox_projectExpenseImportMessages.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.textBox_projectExpenseImportMessages.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.textBox_projectExpenseImportMessages.Location = new System.Drawing.Point(0, 0);
-            this.textBox_projectExpenseImportMessages.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.textBox_projectExpenseImportMessages.Multiline = true;
-            this.textBox_projectExpenseImportMessages.Name = "textBox_projectExpenseImportMessages";
-            this.textBox_projectExpenseImportMessages.ReadOnly = true;
-            this.textBox_projectExpenseImportMessages.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.textBox_projectExpenseImportMessages.Size = new System.Drawing.Size(1437, 307);
-            this.textBox_projectExpenseImportMessages.TabIndex = 0;
-            this.textBox_projectExpenseImportMessages.WordWrap = false;
-            this.defaultToolTip.SetToolTip(this.textBox_projectExpenseImportMessages, "Validation or import status");
-            this.textBox_projectExpenseImportMessages.MouseClick += new System.Windows.Forms.MouseEventHandler(this.textBox_projectExpenseImportMessages_MouseClick);
+            textBox_projectExpenseImportMessages.BackColor = System.Drawing.Color.FromArgb(224, 224, 224);
+            textBox_projectExpenseImportMessages.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            textBox_projectExpenseImportMessages.Dock = System.Windows.Forms.DockStyle.Bottom;
+            textBox_projectExpenseImportMessages.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold);
+            textBox_projectExpenseImportMessages.ForeColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            textBox_projectExpenseImportMessages.Location = new System.Drawing.Point(0, 0);
+            textBox_projectExpenseImportMessages.Multiline = true;
+            textBox_projectExpenseImportMessages.Name = "textBox_projectExpenseImportMessages";
+            textBox_projectExpenseImportMessages.ReadOnly = true;
+            textBox_projectExpenseImportMessages.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            textBox_projectExpenseImportMessages.Size = new System.Drawing.Size(1006, 184);
+            textBox_projectExpenseImportMessages.TabIndex = 0;
+            defaultToolTip.SetToolTip(textBox_projectExpenseImportMessages, "Validation or import status");
+            textBox_projectExpenseImportMessages.WordWrap = false;
+            textBox_projectExpenseImportMessages.MouseClick += textBox_projectExpenseImportMessages_MouseClick;
             // 
             // panel_projectExpenseButtons
             // 
-            this.panel_projectExpenseButtons.Controls.Add(this.button_clear);
-            this.panel_projectExpenseButtons.Controls.Add(this.button_import);
-            this.panel_projectExpenseButtons.Controls.Add(this.button_validate);
-            this.panel_projectExpenseButtons.Controls.Add(this.button_stop);
-            this.panel_projectExpenseButtons.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel_projectExpenseButtons.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.panel_projectExpenseButtons.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.panel_projectExpenseButtons.Location = new System.Drawing.Point(0, 376);
-            this.panel_projectExpenseButtons.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_projectExpenseButtons.Name = "panel_projectExpenseButtons";
-            this.panel_projectExpenseButtons.Size = new System.Drawing.Size(1437, 87);
-            this.panel_projectExpenseButtons.TabIndex = 12;
+            panel_projectExpenseButtons.Controls.Add(button_clear);
+            panel_projectExpenseButtons.Controls.Add(button_import);
+            panel_projectExpenseButtons.Controls.Add(button_validate);
+            panel_projectExpenseButtons.Controls.Add(button_stop);
+            panel_projectExpenseButtons.Dock = System.Windows.Forms.DockStyle.Bottom;
+            panel_projectExpenseButtons.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold);
+            panel_projectExpenseButtons.ForeColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            panel_projectExpenseButtons.Location = new System.Drawing.Point(0, 226);
+            panel_projectExpenseButtons.Name = "panel_projectExpenseButtons";
+            panel_projectExpenseButtons.Size = new System.Drawing.Size(1006, 52);
+            panel_projectExpenseButtons.TabIndex = 12;
             // 
             // button_clear
             // 
-            this.button_clear.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.button_clear.BackColor = System.Drawing.Color.DimGray;
-            this.button_clear.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_clear.FlatAppearance.BorderSize = 0;
-            this.button_clear.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_clear.ForeColor = System.Drawing.Color.White;
-            this.button_clear.Location = new System.Drawing.Point(20, 20);
-            this.button_clear.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_clear.Name = "button_clear";
-            this.button_clear.Size = new System.Drawing.Size(114, 48);
-            this.button_clear.TabIndex = 12;
-            this.button_clear.Text = "Reset All";
-            this.defaultToolTip.SetToolTip(this.button_clear, "Reset everything and reload data from TLP");
-            this.button_clear.UseVisualStyleBackColor = false;
-            this.button_clear.Click += new System.EventHandler(this.button_clear_Click);
+            button_clear.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            button_clear.BackColor = System.Drawing.Color.DimGray;
+            button_clear.Cursor = System.Windows.Forms.Cursors.Hand;
+            button_clear.FlatAppearance.BorderSize = 0;
+            button_clear.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            button_clear.ForeColor = System.Drawing.Color.White;
+            button_clear.Location = new System.Drawing.Point(14, 12);
+            button_clear.Name = "button_clear";
+            button_clear.Size = new System.Drawing.Size(80, 29);
+            button_clear.TabIndex = 12;
+            button_clear.Text = "Reset All";
+            defaultToolTip.SetToolTip(button_clear, "Reset everything and reload data from TLP");
+            button_clear.UseVisualStyleBackColor = false;
+            button_clear.Click += button_clear_Click;
             // 
             // button_import
             // 
-            this.button_import.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.button_import.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(43)))), ((int)(((byte)(141)))));
-            this.button_import.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_import.FlatAppearance.BorderSize = 0;
-            this.button_import.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_import.ForeColor = System.Drawing.Color.White;
-            this.button_import.Location = new System.Drawing.Point(1310, 20);
-            this.button_import.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_import.Name = "button_import";
-            this.button_import.Size = new System.Drawing.Size(114, 48);
-            this.button_import.TabIndex = 7;
-            this.button_import.Text = "Import";
-            this.defaultToolTip.SetToolTip(this.button_import, "Import all data");
-            this.button_import.UseVisualStyleBackColor = false;
-            this.button_import.Click += new System.EventHandler(this.button_import_Click);
+            button_import.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            button_import.BackColor = System.Drawing.Color.FromArgb(226, 43, 141);
+            button_import.Cursor = System.Windows.Forms.Cursors.Hand;
+            button_import.FlatAppearance.BorderSize = 0;
+            button_import.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            button_import.ForeColor = System.Drawing.Color.White;
+            button_import.Location = new System.Drawing.Point(917, 12);
+            button_import.Name = "button_import";
+            button_import.Size = new System.Drawing.Size(80, 29);
+            button_import.TabIndex = 7;
+            button_import.Text = "Import";
+            defaultToolTip.SetToolTip(button_import, "Import all data");
+            button_import.UseVisualStyleBackColor = false;
+            button_import.Click += button_import_Click;
             // 
             // button_validate
             // 
-            this.button_validate.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.button_validate.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(43)))), ((int)(((byte)(141)))));
-            this.button_validate.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_validate.FlatAppearance.BorderSize = 0;
-            this.button_validate.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_validate.ForeColor = System.Drawing.Color.White;
-            this.button_validate.Location = new System.Drawing.Point(1064, 20);
-            this.button_validate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_validate.Name = "button_validate";
-            this.button_validate.Size = new System.Drawing.Size(114, 48);
-            this.button_validate.TabIndex = 8;
-            this.button_validate.Text = "Validate";
-            this.defaultToolTip.SetToolTip(this.button_validate, "Validate data input before importing data");
-            this.button_validate.UseVisualStyleBackColor = false;
-            this.button_validate.Click += new System.EventHandler(this.button_validate_Click);
+            button_validate.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            button_validate.BackColor = System.Drawing.Color.FromArgb(226, 43, 141);
+            button_validate.Cursor = System.Windows.Forms.Cursors.Hand;
+            button_validate.FlatAppearance.BorderSize = 0;
+            button_validate.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            button_validate.ForeColor = System.Drawing.Color.White;
+            button_validate.Location = new System.Drawing.Point(745, 12);
+            button_validate.Name = "button_validate";
+            button_validate.Size = new System.Drawing.Size(80, 29);
+            button_validate.TabIndex = 8;
+            button_validate.Text = "Validate";
+            defaultToolTip.SetToolTip(button_validate, "Validate data input before importing data");
+            button_validate.UseVisualStyleBackColor = false;
+            button_validate.Click += button_validate_Click;
             // 
             // button_stop
             // 
-            this.button_stop.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.button_stop.BackColor = System.Drawing.Color.DimGray;
-            this.button_stop.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_stop.FlatAppearance.BorderSize = 0;
-            this.button_stop.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_stop.ForeColor = System.Drawing.Color.White;
-            this.button_stop.Location = new System.Drawing.Point(1187, 20);
-            this.button_stop.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_stop.Name = "button_stop";
-            this.button_stop.Size = new System.Drawing.Size(114, 48);
-            this.button_stop.TabIndex = 11;
-            this.button_stop.Text = "Stop";
-            this.defaultToolTip.SetToolTip(this.button_stop, "Stop validation or import");
-            this.button_stop.UseVisualStyleBackColor = false;
-            this.button_stop.Click += new System.EventHandler(this.button_stop_Click);
+            button_stop.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            button_stop.BackColor = System.Drawing.Color.DimGray;
+            button_stop.Cursor = System.Windows.Forms.Cursors.Hand;
+            button_stop.FlatAppearance.BorderSize = 0;
+            button_stop.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            button_stop.ForeColor = System.Drawing.Color.White;
+            button_stop.Location = new System.Drawing.Point(831, 12);
+            button_stop.Name = "button_stop";
+            button_stop.Size = new System.Drawing.Size(80, 29);
+            button_stop.TabIndex = 11;
+            button_stop.Text = "Stop";
+            defaultToolTip.SetToolTip(button_stop, "Stop validation or import");
+            button_stop.UseVisualStyleBackColor = false;
+            button_stop.Click += button_stop_Click;
             // 
             // panel_projectExpenseFieldMapping
             // 
-            this.panel_projectExpenseFieldMapping.AutoScroll = true;
-            this.panel_projectExpenseFieldMapping.Controls.Add(this.flowLayoutPanel_nonMandatoryFields);
-            this.panel_projectExpenseFieldMapping.Controls.Add(this.label_delimiter);
-            this.panel_projectExpenseFieldMapping.Controls.Add(this.comboBox_delimiter);
-            this.panel_projectExpenseFieldMapping.Controls.Add(this.groupBox_projectExpenseMandatoryFields);
-            this.panel_projectExpenseFieldMapping.Controls.Add(this.label_projectExpenseSetup);
-            this.panel_projectExpenseFieldMapping.Controls.Add(this.button_projectExpenseSelectFile);
-            this.panel_projectExpenseFieldMapping.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel_projectExpenseFieldMapping.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.panel_projectExpenseFieldMapping.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.panel_projectExpenseFieldMapping.Location = new System.Drawing.Point(0, 0);
-            this.panel_projectExpenseFieldMapping.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_projectExpenseFieldMapping.Name = "panel_projectExpenseFieldMapping";
-            this.panel_projectExpenseFieldMapping.Size = new System.Drawing.Size(1437, 376);
-            this.panel_projectExpenseFieldMapping.TabIndex = 13;
+            panel_projectExpenseFieldMapping.AutoScroll = true;
+            panel_projectExpenseFieldMapping.Controls.Add(flowLayoutPanel_nonMandatoryFields);
+            panel_projectExpenseFieldMapping.Controls.Add(label_delimiter);
+            panel_projectExpenseFieldMapping.Controls.Add(comboBox_delimiter);
+            panel_projectExpenseFieldMapping.Controls.Add(groupBox_projectExpenseMandatoryFields);
+            panel_projectExpenseFieldMapping.Controls.Add(label_projectExpenseSetup);
+            panel_projectExpenseFieldMapping.Controls.Add(button_projectExpenseSelectFile);
+            panel_projectExpenseFieldMapping.Dock = System.Windows.Forms.DockStyle.Fill;
+            panel_projectExpenseFieldMapping.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold);
+            panel_projectExpenseFieldMapping.ForeColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            panel_projectExpenseFieldMapping.Location = new System.Drawing.Point(0, 0);
+            panel_projectExpenseFieldMapping.Name = "panel_projectExpenseFieldMapping";
+            panel_projectExpenseFieldMapping.Size = new System.Drawing.Size(1006, 226);
+            panel_projectExpenseFieldMapping.TabIndex = 13;
             // 
             // flowLayoutPanel_nonMandatoryFields
             // 
-            this.flowLayoutPanel_nonMandatoryFields.Controls.Add(this.panel_NonMandatoryButton);
-            this.flowLayoutPanel_nonMandatoryFields.Controls.Add(this.panel_NonMandatoryFields);
-            this.flowLayoutPanel_nonMandatoryFields.Location = new System.Drawing.Point(817, 100);
-            this.flowLayoutPanel_nonMandatoryFields.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.flowLayoutPanel_nonMandatoryFields.Name = "flowLayoutPanel_nonMandatoryFields";
-            this.flowLayoutPanel_nonMandatoryFields.Size = new System.Drawing.Size(557, 358);
-            this.flowLayoutPanel_nonMandatoryFields.TabIndex = 7;
+            flowLayoutPanel_nonMandatoryFields.Controls.Add(panel_NonMandatoryButton);
+            flowLayoutPanel_nonMandatoryFields.Controls.Add(panel_NonMandatoryFields);
+            flowLayoutPanel_nonMandatoryFields.Location = new System.Drawing.Point(572, 60);
+            flowLayoutPanel_nonMandatoryFields.Name = "flowLayoutPanel_nonMandatoryFields";
+            flowLayoutPanel_nonMandatoryFields.Size = new System.Drawing.Size(390, 215);
+            flowLayoutPanel_nonMandatoryFields.TabIndex = 7;
             // 
             // panel_NonMandatoryButton
             // 
-            this.panel_NonMandatoryButton.Controls.Add(this.label_nonMandatoryFields);
-            this.panel_NonMandatoryButton.Controls.Add(this.button_expandNonMandatory);
-            this.panel_NonMandatoryButton.Location = new System.Drawing.Point(4, 5);
-            this.panel_NonMandatoryButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_NonMandatoryButton.Name = "panel_NonMandatoryButton";
-            this.panel_NonMandatoryButton.Size = new System.Drawing.Size(546, 53);
-            this.panel_NonMandatoryButton.TabIndex = 0;
+            panel_NonMandatoryButton.Controls.Add(label_nonMandatoryFields);
+            panel_NonMandatoryButton.Controls.Add(button_expandNonMandatory);
+            panel_NonMandatoryButton.Location = new System.Drawing.Point(3, 3);
+            panel_NonMandatoryButton.Name = "panel_NonMandatoryButton";
+            panel_NonMandatoryButton.Size = new System.Drawing.Size(382, 32);
+            panel_NonMandatoryButton.TabIndex = 0;
             // 
             // label_nonMandatoryFields
             // 
-            this.label_nonMandatoryFields.AutoSize = true;
-            this.label_nonMandatoryFields.ForeColor = System.Drawing.Color.Black;
-            this.label_nonMandatoryFields.Location = new System.Drawing.Point(66, 13);
-            this.label_nonMandatoryFields.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_nonMandatoryFields.Name = "label_nonMandatoryFields";
-            this.label_nonMandatoryFields.Size = new System.Drawing.Size(107, 17);
-            this.label_nonMandatoryFields.TabIndex = 1;
-            this.label_nonMandatoryFields.Text = "Non-Mandatory";
+            label_nonMandatoryFields.AutoSize = true;
+            label_nonMandatoryFields.ForeColor = System.Drawing.Color.Black;
+            label_nonMandatoryFields.Location = new System.Drawing.Point(46, 8);
+            label_nonMandatoryFields.Name = "label_nonMandatoryFields";
+            label_nonMandatoryFields.Size = new System.Drawing.Size(107, 17);
+            label_nonMandatoryFields.TabIndex = 1;
+            label_nonMandatoryFields.Text = "Non-Mandatory";
             // 
             // button_expandNonMandatory
             // 
-            this.button_expandNonMandatory.BackColor = System.Drawing.Color.White;
-            this.button_expandNonMandatory.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button_expandNonMandatory.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_expandNonMandatory.FlatAppearance.BorderSize = 0;
-            this.button_expandNonMandatory.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_expandNonMandatory.ForeColor = System.Drawing.Color.White;
-            this.button_expandNonMandatory.Location = new System.Drawing.Point(14, 2);
-            this.button_expandNonMandatory.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_expandNonMandatory.Name = "button_expandNonMandatory";
-            this.button_expandNonMandatory.Size = new System.Drawing.Size(43, 50);
-            this.button_expandNonMandatory.TabIndex = 0;
-            this.button_expandNonMandatory.UseVisualStyleBackColor = false;
-            this.button_expandNonMandatory.Click += new System.EventHandler(this.button_expand_Click);
+            button_expandNonMandatory.BackColor = System.Drawing.Color.White;
+            button_expandNonMandatory.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            button_expandNonMandatory.Cursor = System.Windows.Forms.Cursors.Hand;
+            button_expandNonMandatory.FlatAppearance.BorderSize = 0;
+            button_expandNonMandatory.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            button_expandNonMandatory.ForeColor = System.Drawing.Color.White;
+            button_expandNonMandatory.Location = new System.Drawing.Point(10, 1);
+            button_expandNonMandatory.Name = "button_expandNonMandatory";
+            button_expandNonMandatory.Size = new System.Drawing.Size(30, 30);
+            button_expandNonMandatory.TabIndex = 0;
+            button_expandNonMandatory.UseVisualStyleBackColor = false;
+            button_expandNonMandatory.Click += button_expand_Click;
             // 
             // panel_NonMandatoryFields
             // 
-            this.panel_NonMandatoryFields.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_profitRatio);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_profitRatio);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_externalID);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_externalID);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_supplierInvoiceNo);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_supplierInvoiceNo);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_comment);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_comment);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_supplierNo);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_supplierNo);
-            this.panel_NonMandatoryFields.Location = new System.Drawing.Point(4, 68);
-            this.panel_NonMandatoryFields.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_NonMandatoryFields.MaximumSize = new System.Drawing.Size(546, 275);
-            this.panel_NonMandatoryFields.MinimumSize = new System.Drawing.Size(546, 0);
-            this.panel_NonMandatoryFields.Name = "panel_NonMandatoryFields";
-            this.panel_NonMandatoryFields.Size = new System.Drawing.Size(546, 275);
-            this.panel_NonMandatoryFields.TabIndex = 1;
+            panel_NonMandatoryFields.BackColor = System.Drawing.Color.FromArgb(224, 224, 224);
+            panel_NonMandatoryFields.Controls.Add(comboBox_profitRatio);
+            panel_NonMandatoryFields.Controls.Add(label_profitRatio);
+            panel_NonMandatoryFields.Controls.Add(label_externalID);
+            panel_NonMandatoryFields.Controls.Add(comboBox_externalID);
+            panel_NonMandatoryFields.Controls.Add(label_supplierInvoiceNo);
+            panel_NonMandatoryFields.Controls.Add(comboBox_supplierInvoiceNo);
+            panel_NonMandatoryFields.Controls.Add(comboBox_comment);
+            panel_NonMandatoryFields.Controls.Add(label_comment);
+            panel_NonMandatoryFields.Controls.Add(label_supplierNo);
+            panel_NonMandatoryFields.Controls.Add(comboBox_supplierNo);
+            panel_NonMandatoryFields.Location = new System.Drawing.Point(3, 41);
+            panel_NonMandatoryFields.MaximumSize = new System.Drawing.Size(382, 165);
+            panel_NonMandatoryFields.MinimumSize = new System.Drawing.Size(382, 0);
+            panel_NonMandatoryFields.Name = "panel_NonMandatoryFields";
+            panel_NonMandatoryFields.Size = new System.Drawing.Size(382, 165);
+            panel_NonMandatoryFields.TabIndex = 1;
             // 
             // comboBox_profitRatio
             // 
-            this.comboBox_profitRatio.FormattingEnabled = true;
-            this.comboBox_profitRatio.Location = new System.Drawing.Point(219, 218);
-            this.comboBox_profitRatio.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_profitRatio.Name = "comboBox_profitRatio";
-            this.comboBox_profitRatio.Size = new System.Drawing.Size(213, 25);
-            this.comboBox_profitRatio.TabIndex = 10;
+            comboBox_profitRatio.FormattingEnabled = true;
+            comboBox_profitRatio.Location = new System.Drawing.Point(153, 131);
+            comboBox_profitRatio.Name = "comboBox_profitRatio";
+            comboBox_profitRatio.Size = new System.Drawing.Size(150, 25);
+            comboBox_profitRatio.TabIndex = 10;
             // 
             // label_profitRatio
             // 
-            this.label_profitRatio.AutoSize = true;
-            this.label_profitRatio.Location = new System.Drawing.Point(14, 223);
-            this.label_profitRatio.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_profitRatio.Name = "label_profitRatio";
-            this.label_profitRatio.Size = new System.Drawing.Size(76, 17);
-            this.label_profitRatio.TabIndex = 1;
-            this.label_profitRatio.Text = "Profit Ratio";
+            label_profitRatio.AutoSize = true;
+            label_profitRatio.Location = new System.Drawing.Point(10, 134);
+            label_profitRatio.Name = "label_profitRatio";
+            label_profitRatio.Size = new System.Drawing.Size(76, 17);
+            label_profitRatio.TabIndex = 1;
+            label_profitRatio.Text = "Profit Ratio";
             // 
             // label_externalID
             // 
-            this.label_externalID.AutoSize = true;
-            this.label_externalID.Location = new System.Drawing.Point(14, 17);
-            this.label_externalID.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_externalID.Name = "label_externalID";
-            this.label_externalID.Size = new System.Drawing.Size(74, 17);
-            this.label_externalID.TabIndex = 1;
-            this.label_externalID.Text = "External ID";
+            label_externalID.AutoSize = true;
+            label_externalID.Location = new System.Drawing.Point(10, 10);
+            label_externalID.Name = "label_externalID";
+            label_externalID.Size = new System.Drawing.Size(74, 17);
+            label_externalID.TabIndex = 1;
+            label_externalID.Text = "External ID";
             // 
             // comboBox_externalID
             // 
-            this.comboBox_externalID.FormattingEnabled = true;
-            this.comboBox_externalID.Location = new System.Drawing.Point(219, 12);
-            this.comboBox_externalID.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_externalID.Name = "comboBox_externalID";
-            this.comboBox_externalID.Size = new System.Drawing.Size(213, 25);
-            this.comboBox_externalID.TabIndex = 3;
+            comboBox_externalID.FormattingEnabled = true;
+            comboBox_externalID.Location = new System.Drawing.Point(153, 7);
+            comboBox_externalID.Name = "comboBox_externalID";
+            comboBox_externalID.Size = new System.Drawing.Size(150, 25);
+            comboBox_externalID.TabIndex = 3;
             // 
             // label_supplierInvoiceNo
             // 
-            this.label_supplierInvoiceNo.AutoSize = true;
-            this.label_supplierInvoiceNo.Location = new System.Drawing.Point(14, 172);
-            this.label_supplierInvoiceNo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_supplierInvoiceNo.Name = "label_supplierInvoiceNo";
-            this.label_supplierInvoiceNo.Size = new System.Drawing.Size(126, 17);
-            this.label_supplierInvoiceNo.TabIndex = 1;
-            this.label_supplierInvoiceNo.Text = "Supplier Invoice No";
+            label_supplierInvoiceNo.AutoSize = true;
+            label_supplierInvoiceNo.Location = new System.Drawing.Point(10, 103);
+            label_supplierInvoiceNo.Name = "label_supplierInvoiceNo";
+            label_supplierInvoiceNo.Size = new System.Drawing.Size(126, 17);
+            label_supplierInvoiceNo.TabIndex = 1;
+            label_supplierInvoiceNo.Text = "Supplier Invoice No";
             // 
             // comboBox_supplierInvoiceNo
             // 
-            this.comboBox_supplierInvoiceNo.FormattingEnabled = true;
-            this.comboBox_supplierInvoiceNo.Location = new System.Drawing.Point(219, 167);
-            this.comboBox_supplierInvoiceNo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_supplierInvoiceNo.Name = "comboBox_supplierInvoiceNo";
-            this.comboBox_supplierInvoiceNo.Size = new System.Drawing.Size(213, 25);
-            this.comboBox_supplierInvoiceNo.TabIndex = 3;
+            comboBox_supplierInvoiceNo.FormattingEnabled = true;
+            comboBox_supplierInvoiceNo.Location = new System.Drawing.Point(153, 100);
+            comboBox_supplierInvoiceNo.Name = "comboBox_supplierInvoiceNo";
+            comboBox_supplierInvoiceNo.Size = new System.Drawing.Size(150, 25);
+            comboBox_supplierInvoiceNo.TabIndex = 3;
             // 
             // comboBox_comment
             // 
-            this.comboBox_comment.FormattingEnabled = true;
-            this.comboBox_comment.Location = new System.Drawing.Point(219, 63);
-            this.comboBox_comment.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_comment.Name = "comboBox_comment";
-            this.comboBox_comment.Size = new System.Drawing.Size(213, 25);
-            this.comboBox_comment.TabIndex = 3;
+            comboBox_comment.FormattingEnabled = true;
+            comboBox_comment.Location = new System.Drawing.Point(153, 38);
+            comboBox_comment.Name = "comboBox_comment";
+            comboBox_comment.Size = new System.Drawing.Size(150, 25);
+            comboBox_comment.TabIndex = 3;
             // 
             // label_comment
             // 
-            this.label_comment.AutoSize = true;
-            this.label_comment.Location = new System.Drawing.Point(14, 68);
-            this.label_comment.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_comment.Name = "label_comment";
-            this.label_comment.Size = new System.Drawing.Size(68, 17);
-            this.label_comment.TabIndex = 1;
-            this.label_comment.Text = "Comment";
+            label_comment.AutoSize = true;
+            label_comment.Location = new System.Drawing.Point(10, 41);
+            label_comment.Name = "label_comment";
+            label_comment.Size = new System.Drawing.Size(68, 17);
+            label_comment.TabIndex = 1;
+            label_comment.Text = "Comment";
             // 
             // label_supplierNo
             // 
-            this.label_supplierNo.AutoSize = true;
-            this.label_supplierNo.Location = new System.Drawing.Point(14, 120);
-            this.label_supplierNo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_supplierNo.Name = "label_supplierNo";
-            this.label_supplierNo.Size = new System.Drawing.Size(79, 17);
-            this.label_supplierNo.TabIndex = 1;
-            this.label_supplierNo.Text = "Supplier No";
+            label_supplierNo.AutoSize = true;
+            label_supplierNo.Location = new System.Drawing.Point(10, 72);
+            label_supplierNo.Name = "label_supplierNo";
+            label_supplierNo.Size = new System.Drawing.Size(79, 17);
+            label_supplierNo.TabIndex = 1;
+            label_supplierNo.Text = "Supplier No";
             // 
             // comboBox_supplierNo
             // 
-            this.comboBox_supplierNo.FormattingEnabled = true;
-            this.comboBox_supplierNo.Location = new System.Drawing.Point(219, 115);
-            this.comboBox_supplierNo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_supplierNo.Name = "comboBox_supplierNo";
-            this.comboBox_supplierNo.Size = new System.Drawing.Size(213, 25);
-            this.comboBox_supplierNo.TabIndex = 3;
+            comboBox_supplierNo.FormattingEnabled = true;
+            comboBox_supplierNo.Location = new System.Drawing.Point(153, 69);
+            comboBox_supplierNo.Name = "comboBox_supplierNo";
+            comboBox_supplierNo.Size = new System.Drawing.Size(150, 25);
+            comboBox_supplierNo.TabIndex = 3;
             // 
             // label_delimiter
             // 
-            this.label_delimiter.AutoSize = true;
-            this.label_delimiter.Location = new System.Drawing.Point(14, 125);
-            this.label_delimiter.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_delimiter.Name = "label_delimiter";
-            this.label_delimiter.Size = new System.Drawing.Size(62, 17);
-            this.label_delimiter.TabIndex = 1;
-            this.label_delimiter.Text = "Delimiter";
+            label_delimiter.AutoSize = true;
+            label_delimiter.Location = new System.Drawing.Point(10, 75);
+            label_delimiter.Name = "label_delimiter";
+            label_delimiter.Size = new System.Drawing.Size(62, 17);
+            label_delimiter.TabIndex = 1;
+            label_delimiter.Text = "Delimiter";
             // 
             // comboBox_delimiter
             // 
-            this.comboBox_delimiter.FormattingEnabled = true;
-            this.comboBox_delimiter.Location = new System.Drawing.Point(117, 120);
-            this.comboBox_delimiter.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_delimiter.Name = "comboBox_delimiter";
-            this.comboBox_delimiter.Size = new System.Drawing.Size(78, 25);
-            this.comboBox_delimiter.TabIndex = 6;
+            comboBox_delimiter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboBox_delimiter.FormattingEnabled = true;
+            comboBox_delimiter.Location = new System.Drawing.Point(82, 72);
+            comboBox_delimiter.Name = "comboBox_delimiter";
+            comboBox_delimiter.Size = new System.Drawing.Size(56, 25);
+            comboBox_delimiter.TabIndex = 6;
             // 
             // groupBox_projectExpenseMandatoryFields
             // 
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.checkBox_defaultIsBillable);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.checkBox_defaultExpenseCurrencyISO);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.comboBox_contractName);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.comboBox_expenseCurrencyISO);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.comboBox_VATAmount);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.comboBox_expenseNo);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.label_contractName);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.label_expenseCurrencyISO);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.label_VATAmountCurrency);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.label_expenseNo);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.checkBox_defaultExpenseType);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.checkBox_defaultPaymentMethod);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.label_salesPriceAmount);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.comboBox_salesPriceAmount);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.comboBox_exchangeRate);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.label_amountIncludingVAT);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.label_isBillable);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.label_exchangeRate);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.comboBox_amountIncludingVAT);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.label_expenseType);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.comboBox_expenseType);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.label_paymentMethod);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.comboBox_isBillable);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.comboBox_paymentMethod);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.label_purchaseDate);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.comboBox_purchaseDate);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.label_projectNo);
-            this.groupBox_projectExpenseMandatoryFields.Controls.Add(this.comboBox_projectNo);
-            this.groupBox_projectExpenseMandatoryFields.Location = new System.Drawing.Point(229, 103);
-            this.groupBox_projectExpenseMandatoryFields.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.groupBox_projectExpenseMandatoryFields.Name = "groupBox_projectExpenseMandatoryFields";
-            this.groupBox_projectExpenseMandatoryFields.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.groupBox_projectExpenseMandatoryFields.Size = new System.Drawing.Size(563, 675);
-            this.groupBox_projectExpenseMandatoryFields.TabIndex = 5;
-            this.groupBox_projectExpenseMandatoryFields.TabStop = false;
-            this.groupBox_projectExpenseMandatoryFields.Text = "Mandatory";
+            groupBox_projectExpenseMandatoryFields.Controls.Add(checkBox_defaultIsBillable);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(checkBox_defaultExpenseCurrencyISO);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(comboBox_contractName);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(comboBox_expenseCurrencyISO);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(comboBox_VATAmount);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(comboBox_expenseNo);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(label_contractName);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(label_expenseCurrencyISO);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(label_VATAmountCurrency);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(label_expenseNo);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(checkBox_defaultExpenseType);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(checkBox_defaultPaymentMethod);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(label_salesPriceAmount);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(comboBox_salesPriceAmount);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(comboBox_exchangeRate);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(label_amountIncludingVAT);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(label_isBillable);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(label_exchangeRate);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(comboBox_amountIncludingVAT);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(label_expenseType);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(comboBox_expenseType);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(label_paymentMethod);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(comboBox_isBillable);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(comboBox_paymentMethod);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(label_purchaseDate);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(comboBox_purchaseDate);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(label_projectNo);
+            groupBox_projectExpenseMandatoryFields.Controls.Add(comboBox_projectNo);
+            groupBox_projectExpenseMandatoryFields.Location = new System.Drawing.Point(160, 62);
+            groupBox_projectExpenseMandatoryFields.Name = "groupBox_projectExpenseMandatoryFields";
+            groupBox_projectExpenseMandatoryFields.Size = new System.Drawing.Size(394, 405);
+            groupBox_projectExpenseMandatoryFields.TabIndex = 5;
+            groupBox_projectExpenseMandatoryFields.TabStop = false;
+            groupBox_projectExpenseMandatoryFields.Text = "Mandatory";
             // 
             // checkBox_defaultIsBillable
             // 
-            this.checkBox_defaultIsBillable.AutoSize = true;
-            this.checkBox_defaultIsBillable.Location = new System.Drawing.Point(461, 353);
-            this.checkBox_defaultIsBillable.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultIsBillable.Name = "checkBox_defaultIsBillable";
-            this.checkBox_defaultIsBillable.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultIsBillable.TabIndex = 14;
-            this.checkBox_defaultIsBillable.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultIsBillable, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultIsBillable.UseVisualStyleBackColor = true;
-            this.checkBox_defaultIsBillable.CheckedChanged += new System.EventHandler(this.checkBox_defaultIsBillable_CheckedChanged);
+            checkBox_defaultIsBillable.AutoSize = true;
+            checkBox_defaultIsBillable.Location = new System.Drawing.Point(323, 212);
+            checkBox_defaultIsBillable.Name = "checkBox_defaultIsBillable";
+            checkBox_defaultIsBillable.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultIsBillable.TabIndex = 14;
+            checkBox_defaultIsBillable.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultIsBillable, "Set default values for all rows of a particular column field");
+            checkBox_defaultIsBillable.UseVisualStyleBackColor = true;
+            checkBox_defaultIsBillable.CheckedChanged += checkBox_defaultIsBillable_CheckedChanged;
             // 
             // checkBox_defaultExpenseCurrencyISO
             // 
-            this.checkBox_defaultExpenseCurrencyISO.AutoSize = true;
-            this.checkBox_defaultExpenseCurrencyISO.Location = new System.Drawing.Point(461, 508);
-            this.checkBox_defaultExpenseCurrencyISO.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultExpenseCurrencyISO.Name = "checkBox_defaultExpenseCurrencyISO";
-            this.checkBox_defaultExpenseCurrencyISO.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultExpenseCurrencyISO.TabIndex = 12;
-            this.checkBox_defaultExpenseCurrencyISO.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultExpenseCurrencyISO, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultExpenseCurrencyISO.UseVisualStyleBackColor = true;
-            this.checkBox_defaultExpenseCurrencyISO.CheckedChanged += new System.EventHandler(this.checkBox_defaultExpenseCurrencyISO_CheckedChanged);
+            checkBox_defaultExpenseCurrencyISO.AutoSize = true;
+            checkBox_defaultExpenseCurrencyISO.Location = new System.Drawing.Point(323, 305);
+            checkBox_defaultExpenseCurrencyISO.Name = "checkBox_defaultExpenseCurrencyISO";
+            checkBox_defaultExpenseCurrencyISO.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultExpenseCurrencyISO.TabIndex = 12;
+            checkBox_defaultExpenseCurrencyISO.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultExpenseCurrencyISO, "Set default values for all rows of a particular column field");
+            checkBox_defaultExpenseCurrencyISO.UseVisualStyleBackColor = true;
+            checkBox_defaultExpenseCurrencyISO.CheckedChanged += checkBox_defaultExpenseCurrencyISO_CheckedChanged;
             // 
             // comboBox_contractName
             // 
-            this.comboBox_contractName.FormattingEnabled = true;
-            this.comboBox_contractName.Location = new System.Drawing.Point(233, 557);
-            this.comboBox_contractName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_contractName.Name = "comboBox_contractName";
-            this.comboBox_contractName.Size = new System.Drawing.Size(218, 25);
-            this.comboBox_contractName.TabIndex = 10;
+            comboBox_contractName.FormattingEnabled = true;
+            comboBox_contractName.Location = new System.Drawing.Point(163, 334);
+            comboBox_contractName.Name = "comboBox_contractName";
+            comboBox_contractName.Size = new System.Drawing.Size(154, 25);
+            comboBox_contractName.TabIndex = 10;
             // 
             // comboBox_expenseCurrencyISO
             // 
-            this.comboBox_expenseCurrencyISO.FormattingEnabled = true;
-            this.comboBox_expenseCurrencyISO.Location = new System.Drawing.Point(233, 505);
-            this.comboBox_expenseCurrencyISO.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_expenseCurrencyISO.Name = "comboBox_expenseCurrencyISO";
-            this.comboBox_expenseCurrencyISO.Size = new System.Drawing.Size(218, 25);
-            this.comboBox_expenseCurrencyISO.TabIndex = 9;
+            comboBox_expenseCurrencyISO.FormattingEnabled = true;
+            comboBox_expenseCurrencyISO.Location = new System.Drawing.Point(163, 303);
+            comboBox_expenseCurrencyISO.Name = "comboBox_expenseCurrencyISO";
+            comboBox_expenseCurrencyISO.Size = new System.Drawing.Size(154, 25);
+            comboBox_expenseCurrencyISO.TabIndex = 9;
             // 
             // comboBox_VATAmount
             // 
-            this.comboBox_VATAmount.FormattingEnabled = true;
-            this.comboBox_VATAmount.Location = new System.Drawing.Point(233, 453);
-            this.comboBox_VATAmount.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_VATAmount.Name = "comboBox_VATAmount";
-            this.comboBox_VATAmount.Size = new System.Drawing.Size(218, 25);
-            this.comboBox_VATAmount.TabIndex = 8;
+            comboBox_VATAmount.FormattingEnabled = true;
+            comboBox_VATAmount.Location = new System.Drawing.Point(163, 272);
+            comboBox_VATAmount.Name = "comboBox_VATAmount";
+            comboBox_VATAmount.Size = new System.Drawing.Size(154, 25);
+            comboBox_VATAmount.TabIndex = 8;
             // 
             // comboBox_expenseNo
             // 
-            this.comboBox_expenseNo.FormattingEnabled = true;
-            this.comboBox_expenseNo.Location = new System.Drawing.Point(233, 402);
-            this.comboBox_expenseNo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_expenseNo.Name = "comboBox_expenseNo";
-            this.comboBox_expenseNo.Size = new System.Drawing.Size(218, 25);
-            this.comboBox_expenseNo.TabIndex = 7;
+            comboBox_expenseNo.FormattingEnabled = true;
+            comboBox_expenseNo.Location = new System.Drawing.Point(163, 241);
+            comboBox_expenseNo.Name = "comboBox_expenseNo";
+            comboBox_expenseNo.Size = new System.Drawing.Size(154, 25);
+            comboBox_expenseNo.TabIndex = 7;
             // 
             // label_contractName
             // 
-            this.label_contractName.AutoSize = true;
-            this.label_contractName.Location = new System.Drawing.Point(9, 562);
-            this.label_contractName.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_contractName.Name = "label_contractName";
-            this.label_contractName.Size = new System.Drawing.Size(100, 17);
-            this.label_contractName.TabIndex = 1;
-            this.label_contractName.Text = "Contract Name";
+            label_contractName.AutoSize = true;
+            label_contractName.Location = new System.Drawing.Point(6, 337);
+            label_contractName.Name = "label_contractName";
+            label_contractName.Size = new System.Drawing.Size(100, 17);
+            label_contractName.TabIndex = 1;
+            label_contractName.Text = "Contract Name";
             // 
             // label_expenseCurrencyISO
             // 
-            this.label_expenseCurrencyISO.AutoSize = true;
-            this.label_expenseCurrencyISO.Location = new System.Drawing.Point(9, 510);
-            this.label_expenseCurrencyISO.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_expenseCurrencyISO.Name = "label_expenseCurrencyISO";
-            this.label_expenseCurrencyISO.Size = new System.Drawing.Size(141, 17);
-            this.label_expenseCurrencyISO.TabIndex = 1;
-            this.label_expenseCurrencyISO.Text = "Expense Currency ISO";
+            label_expenseCurrencyISO.AutoSize = true;
+            label_expenseCurrencyISO.Location = new System.Drawing.Point(6, 306);
+            label_expenseCurrencyISO.Name = "label_expenseCurrencyISO";
+            label_expenseCurrencyISO.Size = new System.Drawing.Size(141, 17);
+            label_expenseCurrencyISO.TabIndex = 1;
+            label_expenseCurrencyISO.Text = "Expense Currency ISO";
             // 
             // label_VATAmountCurrency
             // 
-            this.label_VATAmountCurrency.AutoSize = true;
-            this.label_VATAmountCurrency.Location = new System.Drawing.Point(9, 458);
-            this.label_VATAmountCurrency.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_VATAmountCurrency.Name = "label_VATAmountCurrency";
-            this.label_VATAmountCurrency.Size = new System.Drawing.Size(84, 17);
-            this.label_VATAmountCurrency.TabIndex = 1;
-            this.label_VATAmountCurrency.Text = "VAT Amount";
-            this.defaultToolTip.SetToolTip(this.label_VATAmountCurrency, "In expense currency");
+            label_VATAmountCurrency.AutoSize = true;
+            label_VATAmountCurrency.Location = new System.Drawing.Point(6, 275);
+            label_VATAmountCurrency.Name = "label_VATAmountCurrency";
+            label_VATAmountCurrency.Size = new System.Drawing.Size(84, 17);
+            label_VATAmountCurrency.TabIndex = 1;
+            label_VATAmountCurrency.Text = "VAT Amount";
+            defaultToolTip.SetToolTip(label_VATAmountCurrency, "In expense currency");
             // 
             // label_expenseNo
             // 
-            this.label_expenseNo.AutoSize = true;
-            this.label_expenseNo.Location = new System.Drawing.Point(9, 407);
-            this.label_expenseNo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_expenseNo.Name = "label_expenseNo";
-            this.label_expenseNo.Size = new System.Drawing.Size(80, 17);
-            this.label_expenseNo.TabIndex = 1;
-            this.label_expenseNo.Text = "Expense No";
+            label_expenseNo.AutoSize = true;
+            label_expenseNo.Location = new System.Drawing.Point(6, 244);
+            label_expenseNo.Name = "label_expenseNo";
+            label_expenseNo.Size = new System.Drawing.Size(80, 17);
+            label_expenseNo.TabIndex = 1;
+            label_expenseNo.Text = "Expense No";
             // 
             // checkBox_defaultExpenseType
             // 
-            this.checkBox_defaultExpenseType.AutoSize = true;
-            this.checkBox_defaultExpenseType.Location = new System.Drawing.Point(461, 198);
-            this.checkBox_defaultExpenseType.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultExpenseType.Name = "checkBox_defaultExpenseType";
-            this.checkBox_defaultExpenseType.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultExpenseType.TabIndex = 6;
-            this.checkBox_defaultExpenseType.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultExpenseType, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultExpenseType.UseVisualStyleBackColor = true;
-            this.checkBox_defaultExpenseType.CheckedChanged += new System.EventHandler(this.checkBox_defaultExpenseType_CheckedChanged);
+            checkBox_defaultExpenseType.AutoSize = true;
+            checkBox_defaultExpenseType.Location = new System.Drawing.Point(323, 119);
+            checkBox_defaultExpenseType.Name = "checkBox_defaultExpenseType";
+            checkBox_defaultExpenseType.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultExpenseType.TabIndex = 6;
+            checkBox_defaultExpenseType.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultExpenseType, "Set default values for all rows of a particular column field");
+            checkBox_defaultExpenseType.UseVisualStyleBackColor = true;
+            checkBox_defaultExpenseType.CheckedChanged += checkBox_defaultExpenseType_CheckedChanged;
             // 
             // checkBox_defaultPaymentMethod
             // 
-            this.checkBox_defaultPaymentMethod.AutoSize = true;
-            this.checkBox_defaultPaymentMethod.Location = new System.Drawing.Point(461, 147);
-            this.checkBox_defaultPaymentMethod.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultPaymentMethod.Name = "checkBox_defaultPaymentMethod";
-            this.checkBox_defaultPaymentMethod.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultPaymentMethod.TabIndex = 4;
-            this.checkBox_defaultPaymentMethod.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultPaymentMethod, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultPaymentMethod.UseVisualStyleBackColor = true;
-            this.checkBox_defaultPaymentMethod.CheckedChanged += new System.EventHandler(this.checkBox_defaultPaymentMethod_CheckedChanged);
+            checkBox_defaultPaymentMethod.AutoSize = true;
+            checkBox_defaultPaymentMethod.Location = new System.Drawing.Point(323, 88);
+            checkBox_defaultPaymentMethod.Name = "checkBox_defaultPaymentMethod";
+            checkBox_defaultPaymentMethod.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultPaymentMethod.TabIndex = 4;
+            checkBox_defaultPaymentMethod.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultPaymentMethod, "Set default values for all rows of a particular column field");
+            checkBox_defaultPaymentMethod.UseVisualStyleBackColor = true;
+            checkBox_defaultPaymentMethod.CheckedChanged += checkBox_defaultPaymentMethod_CheckedChanged;
             // 
             // label_salesPriceAmount
             // 
-            this.label_salesPriceAmount.AutoSize = true;
-            this.label_salesPriceAmount.Location = new System.Drawing.Point(9, 303);
-            this.label_salesPriceAmount.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_salesPriceAmount.Name = "label_salesPriceAmount";
-            this.label_salesPriceAmount.Size = new System.Drawing.Size(125, 17);
-            this.label_salesPriceAmount.TabIndex = 1;
-            this.label_salesPriceAmount.Text = "Sales Price Amount";
-            this.defaultToolTip.SetToolTip(this.label_salesPriceAmount, "In project currency");
+            label_salesPriceAmount.AutoSize = true;
+            label_salesPriceAmount.Location = new System.Drawing.Point(6, 182);
+            label_salesPriceAmount.Name = "label_salesPriceAmount";
+            label_salesPriceAmount.Size = new System.Drawing.Size(125, 17);
+            label_salesPriceAmount.TabIndex = 1;
+            label_salesPriceAmount.Text = "Sales Price Amount";
+            defaultToolTip.SetToolTip(label_salesPriceAmount, "In project currency");
             // 
             // comboBox_salesPriceAmount
             // 
-            this.comboBox_salesPriceAmount.FormattingEnabled = true;
-            this.comboBox_salesPriceAmount.Location = new System.Drawing.Point(233, 298);
-            this.comboBox_salesPriceAmount.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_salesPriceAmount.Name = "comboBox_salesPriceAmount";
-            this.comboBox_salesPriceAmount.Size = new System.Drawing.Size(218, 25);
-            this.comboBox_salesPriceAmount.TabIndex = 3;
+            comboBox_salesPriceAmount.FormattingEnabled = true;
+            comboBox_salesPriceAmount.Location = new System.Drawing.Point(163, 179);
+            comboBox_salesPriceAmount.Name = "comboBox_salesPriceAmount";
+            comboBox_salesPriceAmount.Size = new System.Drawing.Size(154, 25);
+            comboBox_salesPriceAmount.TabIndex = 3;
             // 
             // comboBox_exchangeRate
             // 
-            this.comboBox_exchangeRate.FormattingEnabled = true;
-            this.comboBox_exchangeRate.Location = new System.Drawing.Point(233, 608);
-            this.comboBox_exchangeRate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_exchangeRate.Name = "comboBox_exchangeRate";
-            this.comboBox_exchangeRate.Size = new System.Drawing.Size(218, 25);
-            this.comboBox_exchangeRate.TabIndex = 3;
+            comboBox_exchangeRate.FormattingEnabled = true;
+            comboBox_exchangeRate.Location = new System.Drawing.Point(163, 365);
+            comboBox_exchangeRate.Name = "comboBox_exchangeRate";
+            comboBox_exchangeRate.Size = new System.Drawing.Size(154, 25);
+            comboBox_exchangeRate.TabIndex = 3;
             // 
             // label_amountIncludingVAT
             // 
-            this.label_amountIncludingVAT.AutoSize = true;
-            this.label_amountIncludingVAT.Location = new System.Drawing.Point(9, 252);
-            this.label_amountIncludingVAT.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_amountIncludingVAT.Name = "label_amountIncludingVAT";
-            this.label_amountIncludingVAT.Size = new System.Drawing.Size(108, 17);
-            this.label_amountIncludingVAT.TabIndex = 1;
-            this.label_amountIncludingVAT.Text = "Amount inc. VAT";
-            this.defaultToolTip.SetToolTip(this.label_amountIncludingVAT, "In expense currency");
+            label_amountIncludingVAT.AutoSize = true;
+            label_amountIncludingVAT.Location = new System.Drawing.Point(6, 151);
+            label_amountIncludingVAT.Name = "label_amountIncludingVAT";
+            label_amountIncludingVAT.Size = new System.Drawing.Size(108, 17);
+            label_amountIncludingVAT.TabIndex = 1;
+            label_amountIncludingVAT.Text = "Amount inc. VAT";
+            defaultToolTip.SetToolTip(label_amountIncludingVAT, "In expense currency");
             // 
             // label_isBillable
             // 
-            this.label_isBillable.AutoSize = true;
-            this.label_isBillable.Location = new System.Drawing.Point(9, 355);
-            this.label_isBillable.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_isBillable.Name = "label_isBillable";
-            this.label_isBillable.Size = new System.Drawing.Size(64, 17);
-            this.label_isBillable.TabIndex = 1;
-            this.label_isBillable.Text = "Is Billable";
+            label_isBillable.AutoSize = true;
+            label_isBillable.Location = new System.Drawing.Point(6, 213);
+            label_isBillable.Name = "label_isBillable";
+            label_isBillable.Size = new System.Drawing.Size(64, 17);
+            label_isBillable.TabIndex = 1;
+            label_isBillable.Text = "Is Billable";
             // 
             // label_exchangeRate
             // 
-            this.label_exchangeRate.AutoSize = true;
-            this.label_exchangeRate.Location = new System.Drawing.Point(9, 613);
-            this.label_exchangeRate.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_exchangeRate.Name = "label_exchangeRate";
-            this.label_exchangeRate.Size = new System.Drawing.Size(97, 17);
-            this.label_exchangeRate.TabIndex = 1;
-            this.label_exchangeRate.Text = "Exchange Rate";
+            label_exchangeRate.AutoSize = true;
+            label_exchangeRate.Location = new System.Drawing.Point(6, 368);
+            label_exchangeRate.Name = "label_exchangeRate";
+            label_exchangeRate.Size = new System.Drawing.Size(97, 17);
+            label_exchangeRate.TabIndex = 1;
+            label_exchangeRate.Text = "Exchange Rate";
             // 
             // comboBox_amountIncludingVAT
             // 
-            this.comboBox_amountIncludingVAT.FormattingEnabled = true;
-            this.comboBox_amountIncludingVAT.Location = new System.Drawing.Point(233, 247);
-            this.comboBox_amountIncludingVAT.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_amountIncludingVAT.Name = "comboBox_amountIncludingVAT";
-            this.comboBox_amountIncludingVAT.Size = new System.Drawing.Size(218, 25);
-            this.comboBox_amountIncludingVAT.TabIndex = 3;
+            comboBox_amountIncludingVAT.FormattingEnabled = true;
+            comboBox_amountIncludingVAT.Location = new System.Drawing.Point(163, 148);
+            comboBox_amountIncludingVAT.Name = "comboBox_amountIncludingVAT";
+            comboBox_amountIncludingVAT.Size = new System.Drawing.Size(154, 25);
+            comboBox_amountIncludingVAT.TabIndex = 3;
             // 
             // label_expenseType
             // 
-            this.label_expenseType.AutoSize = true;
-            this.label_expenseType.Location = new System.Drawing.Point(9, 200);
-            this.label_expenseType.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_expenseType.Name = "label_expenseType";
-            this.label_expenseType.Size = new System.Drawing.Size(90, 17);
-            this.label_expenseType.TabIndex = 1;
-            this.label_expenseType.Text = "Expense Type";
+            label_expenseType.AutoSize = true;
+            label_expenseType.Location = new System.Drawing.Point(6, 120);
+            label_expenseType.Name = "label_expenseType";
+            label_expenseType.Size = new System.Drawing.Size(90, 17);
+            label_expenseType.TabIndex = 1;
+            label_expenseType.Text = "Expense Type";
             // 
             // comboBox_expenseType
             // 
-            this.comboBox_expenseType.FormattingEnabled = true;
-            this.comboBox_expenseType.Location = new System.Drawing.Point(233, 195);
-            this.comboBox_expenseType.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_expenseType.Name = "comboBox_expenseType";
-            this.comboBox_expenseType.Size = new System.Drawing.Size(218, 25);
-            this.comboBox_expenseType.TabIndex = 3;
+            comboBox_expenseType.FormattingEnabled = true;
+            comboBox_expenseType.Location = new System.Drawing.Point(163, 117);
+            comboBox_expenseType.Name = "comboBox_expenseType";
+            comboBox_expenseType.Size = new System.Drawing.Size(154, 25);
+            comboBox_expenseType.TabIndex = 3;
             // 
             // label_paymentMethod
             // 
-            this.label_paymentMethod.AutoSize = true;
-            this.label_paymentMethod.Location = new System.Drawing.Point(9, 148);
-            this.label_paymentMethod.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_paymentMethod.Name = "label_paymentMethod";
-            this.label_paymentMethod.Size = new System.Drawing.Size(114, 17);
-            this.label_paymentMethod.TabIndex = 1;
-            this.label_paymentMethod.Text = "Payment Method";
+            label_paymentMethod.AutoSize = true;
+            label_paymentMethod.Location = new System.Drawing.Point(6, 89);
+            label_paymentMethod.Name = "label_paymentMethod";
+            label_paymentMethod.Size = new System.Drawing.Size(114, 17);
+            label_paymentMethod.TabIndex = 1;
+            label_paymentMethod.Text = "Payment Method";
             // 
             // comboBox_isBillable
             // 
-            this.comboBox_isBillable.FormattingEnabled = true;
-            this.comboBox_isBillable.Location = new System.Drawing.Point(233, 350);
-            this.comboBox_isBillable.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_isBillable.Name = "comboBox_isBillable";
-            this.comboBox_isBillable.Size = new System.Drawing.Size(218, 25);
-            this.comboBox_isBillable.TabIndex = 3;
+            comboBox_isBillable.FormattingEnabled = true;
+            comboBox_isBillable.Location = new System.Drawing.Point(163, 210);
+            comboBox_isBillable.Name = "comboBox_isBillable";
+            comboBox_isBillable.Size = new System.Drawing.Size(154, 25);
+            comboBox_isBillable.TabIndex = 3;
             // 
             // comboBox_paymentMethod
             // 
-            this.comboBox_paymentMethod.FormattingEnabled = true;
-            this.comboBox_paymentMethod.Location = new System.Drawing.Point(233, 143);
-            this.comboBox_paymentMethod.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_paymentMethod.Name = "comboBox_paymentMethod";
-            this.comboBox_paymentMethod.Size = new System.Drawing.Size(218, 25);
-            this.comboBox_paymentMethod.TabIndex = 3;
+            comboBox_paymentMethod.FormattingEnabled = true;
+            comboBox_paymentMethod.Location = new System.Drawing.Point(163, 86);
+            comboBox_paymentMethod.Name = "comboBox_paymentMethod";
+            comboBox_paymentMethod.Size = new System.Drawing.Size(154, 25);
+            comboBox_paymentMethod.TabIndex = 3;
             // 
             // label_purchaseDate
             // 
-            this.label_purchaseDate.AutoSize = true;
-            this.label_purchaseDate.Location = new System.Drawing.Point(9, 97);
-            this.label_purchaseDate.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_purchaseDate.Name = "label_purchaseDate";
-            this.label_purchaseDate.Size = new System.Drawing.Size(95, 17);
-            this.label_purchaseDate.TabIndex = 1;
-            this.label_purchaseDate.Text = "Purchase Date";
+            label_purchaseDate.AutoSize = true;
+            label_purchaseDate.Location = new System.Drawing.Point(6, 58);
+            label_purchaseDate.Name = "label_purchaseDate";
+            label_purchaseDate.Size = new System.Drawing.Size(95, 17);
+            label_purchaseDate.TabIndex = 1;
+            label_purchaseDate.Text = "Purchase Date";
             // 
             // comboBox_purchaseDate
             // 
-            this.comboBox_purchaseDate.FormattingEnabled = true;
-            this.comboBox_purchaseDate.Location = new System.Drawing.Point(233, 92);
-            this.comboBox_purchaseDate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_purchaseDate.Name = "comboBox_purchaseDate";
-            this.comboBox_purchaseDate.Size = new System.Drawing.Size(218, 25);
-            this.comboBox_purchaseDate.TabIndex = 3;
+            comboBox_purchaseDate.FormattingEnabled = true;
+            comboBox_purchaseDate.Location = new System.Drawing.Point(163, 55);
+            comboBox_purchaseDate.Name = "comboBox_purchaseDate";
+            comboBox_purchaseDate.Size = new System.Drawing.Size(154, 25);
+            comboBox_purchaseDate.TabIndex = 3;
             // 
             // label_projectNo
             // 
-            this.label_projectNo.AutoSize = true;
-            this.label_projectNo.Location = new System.Drawing.Point(9, 45);
-            this.label_projectNo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_projectNo.Name = "label_projectNo";
-            this.label_projectNo.Size = new System.Drawing.Size(72, 17);
-            this.label_projectNo.TabIndex = 1;
-            this.label_projectNo.Text = "Project No";
+            label_projectNo.AutoSize = true;
+            label_projectNo.Location = new System.Drawing.Point(6, 27);
+            label_projectNo.Name = "label_projectNo";
+            label_projectNo.Size = new System.Drawing.Size(72, 17);
+            label_projectNo.TabIndex = 1;
+            label_projectNo.Text = "Project No";
             // 
             // comboBox_projectNo
             // 
-            this.comboBox_projectNo.FormattingEnabled = true;
-            this.comboBox_projectNo.Location = new System.Drawing.Point(233, 40);
-            this.comboBox_projectNo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_projectNo.Name = "comboBox_projectNo";
-            this.comboBox_projectNo.Size = new System.Drawing.Size(218, 25);
-            this.comboBox_projectNo.TabIndex = 3;
+            comboBox_projectNo.FormattingEnabled = true;
+            comboBox_projectNo.Location = new System.Drawing.Point(163, 24);
+            comboBox_projectNo.Name = "comboBox_projectNo";
+            comboBox_projectNo.Size = new System.Drawing.Size(154, 25);
+            comboBox_projectNo.TabIndex = 3;
             // 
             // label_projectExpenseSetup
             // 
-            this.label_projectExpenseSetup.AutoSize = true;
-            this.label_projectExpenseSetup.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.label_projectExpenseSetup.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.label_projectExpenseSetup.Location = new System.Drawing.Point(10, 27);
-            this.label_projectExpenseSetup.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_projectExpenseSetup.Name = "label_projectExpenseSetup";
-            this.label_projectExpenseSetup.Size = new System.Drawing.Size(326, 32);
-            this.label_projectExpenseSetup.TabIndex = 0;
-            this.label_projectExpenseSetup.Text = "Project Expense Data Import";
+            label_projectExpenseSetup.AutoSize = true;
+            label_projectExpenseSetup.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold);
+            label_projectExpenseSetup.ForeColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            label_projectExpenseSetup.Location = new System.Drawing.Point(7, 16);
+            label_projectExpenseSetup.Name = "label_projectExpenseSetup";
+            label_projectExpenseSetup.Size = new System.Drawing.Size(326, 32);
+            label_projectExpenseSetup.TabIndex = 0;
+            label_projectExpenseSetup.Text = "Project Expense Data Import";
             // 
             // button_projectExpenseSelectFile
             // 
-            this.button_projectExpenseSelectFile.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(43)))), ((int)(((byte)(141)))));
-            this.button_projectExpenseSelectFile.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_projectExpenseSelectFile.FlatAppearance.BorderSize = 0;
-            this.button_projectExpenseSelectFile.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_projectExpenseSelectFile.ForeColor = System.Drawing.Color.White;
-            this.button_projectExpenseSelectFile.Location = new System.Drawing.Point(19, 185);
-            this.button_projectExpenseSelectFile.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_projectExpenseSelectFile.Name = "button_projectExpenseSelectFile";
-            this.button_projectExpenseSelectFile.Size = new System.Drawing.Size(114, 48);
-            this.button_projectExpenseSelectFile.TabIndex = 4;
-            this.button_projectExpenseSelectFile.Text = "Select File";
-            this.defaultToolTip.SetToolTip(this.button_projectExpenseSelectFile, "Select input CSV file");
-            this.button_projectExpenseSelectFile.UseVisualStyleBackColor = false;
-            this.button_projectExpenseSelectFile.Click += new System.EventHandler(this.button_select_project_file_Click);
+            button_projectExpenseSelectFile.BackColor = System.Drawing.Color.FromArgb(226, 43, 141);
+            button_projectExpenseSelectFile.Cursor = System.Windows.Forms.Cursors.Hand;
+            button_projectExpenseSelectFile.FlatAppearance.BorderSize = 0;
+            button_projectExpenseSelectFile.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            button_projectExpenseSelectFile.ForeColor = System.Drawing.Color.White;
+            button_projectExpenseSelectFile.Location = new System.Drawing.Point(13, 111);
+            button_projectExpenseSelectFile.Name = "button_projectExpenseSelectFile";
+            button_projectExpenseSelectFile.Size = new System.Drawing.Size(80, 29);
+            button_projectExpenseSelectFile.TabIndex = 4;
+            button_projectExpenseSelectFile.Text = "Select File";
+            defaultToolTip.SetToolTip(button_projectExpenseSelectFile, "Select input CSV file");
+            button_projectExpenseSelectFile.UseVisualStyleBackColor = false;
+            button_projectExpenseSelectFile.Click += button_select_project_file_Click;
             // 
             // tmrExpand
             // 
-            this.tmrExpand.Interval = 10;
-            this.tmrExpand.Tick += new System.EventHandler(this.tmrExpand_Tick);
+            tmrExpand.Interval = 10;
+            tmrExpand.Tick += tmrExpand_Tick;
             // 
             // defaultToolTip
             // 
-            this.defaultToolTip.ShowAlways = true;
+            defaultToolTip.ShowAlways = true;
             // 
             // UserControl_ProjectExpenseImport
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.panel_projectExpenseFieldMapping);
-            this.Controls.Add(this.panel_projectExpenseButtons);
-            this.Controls.Add(this.panel_projectMessage);
-            this.Controls.Add(this.panel_employeeDataTable);
-            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.Name = "UserControl_ProjectExpenseImport";
-            this.Size = new System.Drawing.Size(1437, 1070);
-            this.Load += new System.EventHandler(this.UserControl1_Load);
-            this.panel_employeeDataTable.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridView_projectExpense)).EndInit();
-            this.panel_projectMessage.ResumeLayout(false);
-            this.panel_projectMessage.PerformLayout();
-            this.panel_projectExpenseButtons.ResumeLayout(false);
-            this.panel_projectExpenseFieldMapping.ResumeLayout(false);
-            this.panel_projectExpenseFieldMapping.PerformLayout();
-            this.flowLayoutPanel_nonMandatoryFields.ResumeLayout(false);
-            this.panel_NonMandatoryButton.ResumeLayout(false);
-            this.panel_NonMandatoryButton.PerformLayout();
-            this.panel_NonMandatoryFields.ResumeLayout(false);
-            this.panel_NonMandatoryFields.PerformLayout();
-            this.groupBox_projectExpenseMandatoryFields.ResumeLayout(false);
-            this.groupBox_projectExpenseMandatoryFields.PerformLayout();
-            this.ResumeLayout(false);
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(panel_projectExpenseFieldMapping);
+            Controls.Add(panel_projectExpenseButtons);
+            Controls.Add(panel_projectMessage);
+            Controls.Add(panel_employeeDataTable);
+            Name = "UserControl_ProjectExpenseImport";
+            Size = new System.Drawing.Size(1006, 642);
+            Load += UserControl1_Load;
+            panel_employeeDataTable.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)dataGridView_projectExpense).EndInit();
+            panel_projectMessage.ResumeLayout(false);
+            panel_projectMessage.PerformLayout();
+            panel_projectExpenseButtons.ResumeLayout(false);
+            panel_projectExpenseFieldMapping.ResumeLayout(false);
+            panel_projectExpenseFieldMapping.PerformLayout();
+            flowLayoutPanel_nonMandatoryFields.ResumeLayout(false);
+            panel_NonMandatoryButton.ResumeLayout(false);
+            panel_NonMandatoryButton.PerformLayout();
+            panel_NonMandatoryFields.ResumeLayout(false);
+            panel_NonMandatoryFields.PerformLayout();
+            groupBox_projectExpenseMandatoryFields.ResumeLayout(false);
+            groupBox_projectExpenseMandatoryFields.PerformLayout();
+            ResumeLayout(false);
 
         }
 

--- a/UserControls/UserControl_ProjectExpenseImport.resx
+++ b/UserControls/UserControl_ProjectExpenseImport.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -57,4 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="WorkerFetcher.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="defaultToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>259, 17</value>
+  </metadata>
+  <metadata name="tmrExpand.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>148, 17</value>
+  </metadata>
 </root>

--- a/UserControls/UserControl_ProjectImport.Designer.cs
+++ b/UserControls/UserControl_ProjectImport.Designer.cs
@@ -28,739 +28,738 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            this.WorkerFetcher = new System.ComponentModel.BackgroundWorker();
-            this.panel_projectDataTable = new System.Windows.Forms.Panel();
-            this.dataGridView_project = new System.Windows.Forms.DataGridView();
-            this.panel_projectMessage = new System.Windows.Forms.Panel();
-            this.textBox_projectImportMessages = new System.Windows.Forms.TextBox();
-            this.panel_projectButtons = new System.Windows.Forms.Panel();
-            this.button_clear = new System.Windows.Forms.Button();
-            this.button_import = new System.Windows.Forms.Button();
-            this.button_validate = new System.Windows.Forms.Button();
-            this.button_stop = new System.Windows.Forms.Button();
-            this.panel_projectFieldMapping = new System.Windows.Forms.Panel();
-            this.flowLayoutPanel_nonMandatoryFields = new System.Windows.Forms.FlowLayoutPanel();
-            this.panel_NonMandatoryButton = new System.Windows.Forms.Panel();
-            this.label_nonMandatoryFields = new System.Windows.Forms.Label();
-            this.button_expandNonMandatory = new System.Windows.Forms.Button();
-            this.panel_NonMandatoryFields = new System.Windows.Forms.Panel();
-            this.comboBox_contactPerson = new System.Windows.Forms.ComboBox();
-            this.label_contactPerson = new System.Windows.Forms.Label();
-            this.checkBox_defaultProjectCategory = new System.Windows.Forms.CheckBox();
-            this.label_projectNo = new System.Windows.Forms.Label();
-            this.comboBox_projectNo = new System.Windows.Forms.ComboBox();
-            this.label_projectCategory = new System.Windows.Forms.Label();
-            this.comboBox_description = new System.Windows.Forms.ComboBox();
-            this.comboBox_projectCategory = new System.Windows.Forms.ComboBox();
-            this.label_description = new System.Windows.Forms.Label();
-            this.comboBox_projectStartDate = new System.Windows.Forms.ComboBox();
-            this.label_projectStartDate = new System.Windows.Forms.Label();
-            this.label_projectEndDate = new System.Windows.Forms.Label();
-            this.comboBox_projectEndDate = new System.Windows.Forms.ComboBox();
-            this.label_delimiter = new System.Windows.Forms.Label();
-            this.comboBox_delimiter = new System.Windows.Forms.ComboBox();
-            this.groupBox_projectMandatoryFields = new System.Windows.Forms.GroupBox();
-            this.checkBox_defaultProjectDepartment = new System.Windows.Forms.CheckBox();
-            this.label_projectDepartment = new System.Windows.Forms.Label();
-            this.comboBox_projectDepartment = new System.Windows.Forms.ComboBox();
-            this.checkBox_defaultLegalEntity = new System.Windows.Forms.CheckBox();
-            this.checkBox_defaultProjectTemplate = new System.Windows.Forms.CheckBox();
-            this.checkBox_defaultProjectType = new System.Windows.Forms.CheckBox();
-            this.checkBox_defaultCurrencyISO = new System.Windows.Forms.CheckBox();
-            this.label_projectLegalEntity = new System.Windows.Forms.Label();
-            this.comboBox_projectLegalEntity = new System.Windows.Forms.ComboBox();
-            this.label_projectCurrencyISO = new System.Windows.Forms.Label();
-            this.label_projectType = new System.Windows.Forms.Label();
-            this.comboBox_projectCurrencyISO = new System.Windows.Forms.ComboBox();
-            this.label_projectManager = new System.Windows.Forms.Label();
-            this.comboBox_projectManager = new System.Windows.Forms.ComboBox();
-            this.label_projectTemplate = new System.Windows.Forms.Label();
-            this.comboBox_projectType = new System.Windows.Forms.ComboBox();
-            this.comboBox_projectTemplate = new System.Windows.Forms.ComboBox();
-            this.label_projectCustomerNo = new System.Windows.Forms.Label();
-            this.comboBox_projectCustomerNo = new System.Windows.Forms.ComboBox();
-            this.label_projectName = new System.Windows.Forms.Label();
-            this.comboBox_projectName = new System.Windows.Forms.ComboBox();
-            this.label_projectSetup = new System.Windows.Forms.Label();
-            this.button_projectSelectFile = new System.Windows.Forms.Button();
-            this.tmrExpand = new System.Windows.Forms.Timer(this.components);
-            this.defaultToolTip = new System.Windows.Forms.ToolTip(this.components);
-            this.comboBox_customerInvRef = new System.Windows.Forms.ComboBox();
-            this.label_customerInvRef = new System.Windows.Forms.Label();
-            this.panel_projectDataTable.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridView_project)).BeginInit();
-            this.panel_projectMessage.SuspendLayout();
-            this.panel_projectButtons.SuspendLayout();
-            this.panel_projectFieldMapping.SuspendLayout();
-            this.flowLayoutPanel_nonMandatoryFields.SuspendLayout();
-            this.panel_NonMandatoryButton.SuspendLayout();
-            this.panel_NonMandatoryFields.SuspendLayout();
-            this.groupBox_projectMandatoryFields.SuspendLayout();
-            this.SuspendLayout();
+            components = new System.ComponentModel.Container();
+            WorkerFetcher = new System.ComponentModel.BackgroundWorker();
+            panel_projectDataTable = new System.Windows.Forms.Panel();
+            dataGridView_project = new System.Windows.Forms.DataGridView();
+            panel_projectMessage = new System.Windows.Forms.Panel();
+            textBox_projectImportMessages = new System.Windows.Forms.TextBox();
+            panel_projectButtons = new System.Windows.Forms.Panel();
+            button_clear = new System.Windows.Forms.Button();
+            button_import = new System.Windows.Forms.Button();
+            button_validate = new System.Windows.Forms.Button();
+            button_stop = new System.Windows.Forms.Button();
+            panel_projectFieldMapping = new System.Windows.Forms.Panel();
+            flowLayoutPanel_nonMandatoryFields = new System.Windows.Forms.FlowLayoutPanel();
+            panel_NonMandatoryButton = new System.Windows.Forms.Panel();
+            label_nonMandatoryFields = new System.Windows.Forms.Label();
+            button_expandNonMandatory = new System.Windows.Forms.Button();
+            panel_NonMandatoryFields = new System.Windows.Forms.Panel();
+            comboBox_customerInvRef = new System.Windows.Forms.ComboBox();
+            label_customerInvRef = new System.Windows.Forms.Label();
+            comboBox_contactPerson = new System.Windows.Forms.ComboBox();
+            label_contactPerson = new System.Windows.Forms.Label();
+            checkBox_defaultProjectCategory = new System.Windows.Forms.CheckBox();
+            label_projectNo = new System.Windows.Forms.Label();
+            comboBox_projectNo = new System.Windows.Forms.ComboBox();
+            label_projectCategory = new System.Windows.Forms.Label();
+            comboBox_description = new System.Windows.Forms.ComboBox();
+            comboBox_projectCategory = new System.Windows.Forms.ComboBox();
+            label_description = new System.Windows.Forms.Label();
+            comboBox_projectStartDate = new System.Windows.Forms.ComboBox();
+            label_projectStartDate = new System.Windows.Forms.Label();
+            label_projectEndDate = new System.Windows.Forms.Label();
+            comboBox_projectEndDate = new System.Windows.Forms.ComboBox();
+            label_delimiter = new System.Windows.Forms.Label();
+            comboBox_delimiter = new System.Windows.Forms.ComboBox();
+            groupBox_projectMandatoryFields = new System.Windows.Forms.GroupBox();
+            checkBox_defaultProjectDepartment = new System.Windows.Forms.CheckBox();
+            label_projectDepartment = new System.Windows.Forms.Label();
+            comboBox_projectDepartment = new System.Windows.Forms.ComboBox();
+            checkBox_defaultLegalEntity = new System.Windows.Forms.CheckBox();
+            checkBox_defaultProjectTemplate = new System.Windows.Forms.CheckBox();
+            checkBox_defaultProjectType = new System.Windows.Forms.CheckBox();
+            checkBox_defaultCurrencyISO = new System.Windows.Forms.CheckBox();
+            label_projectLegalEntity = new System.Windows.Forms.Label();
+            comboBox_projectLegalEntity = new System.Windows.Forms.ComboBox();
+            label_projectCurrencyISO = new System.Windows.Forms.Label();
+            label_projectType = new System.Windows.Forms.Label();
+            comboBox_projectCurrencyISO = new System.Windows.Forms.ComboBox();
+            label_projectManager = new System.Windows.Forms.Label();
+            comboBox_projectManager = new System.Windows.Forms.ComboBox();
+            label_projectTemplate = new System.Windows.Forms.Label();
+            comboBox_projectType = new System.Windows.Forms.ComboBox();
+            comboBox_projectTemplate = new System.Windows.Forms.ComboBox();
+            label_projectCustomerNo = new System.Windows.Forms.Label();
+            comboBox_projectCustomerNo = new System.Windows.Forms.ComboBox();
+            label_projectName = new System.Windows.Forms.Label();
+            comboBox_projectName = new System.Windows.Forms.ComboBox();
+            label_projectSetup = new System.Windows.Forms.Label();
+            button_projectSelectFile = new System.Windows.Forms.Button();
+            tmrExpand = new System.Windows.Forms.Timer(components);
+            defaultToolTip = new System.Windows.Forms.ToolTip(components);
+            panel_projectDataTable.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)dataGridView_project).BeginInit();
+            panel_projectMessage.SuspendLayout();
+            panel_projectButtons.SuspendLayout();
+            panel_projectFieldMapping.SuspendLayout();
+            flowLayoutPanel_nonMandatoryFields.SuspendLayout();
+            panel_NonMandatoryButton.SuspendLayout();
+            panel_NonMandatoryFields.SuspendLayout();
+            groupBox_projectMandatoryFields.SuspendLayout();
+            SuspendLayout();
             // 
             // WorkerFetcher
             // 
-            this.WorkerFetcher.WorkerReportsProgress = true;
-            this.WorkerFetcher.WorkerSupportsCancellation = true;
-            this.WorkerFetcher.DoWork += WorkerFetcherDoWork;
+            WorkerFetcher.WorkerReportsProgress = true;
+            WorkerFetcher.WorkerSupportsCancellation = true;
+            WorkerFetcher.DoWork += WorkerFetcherDoWork;
             // 
             // panel_projectDataTable
             // 
-            this.panel_projectDataTable.Controls.Add(this.dataGridView_project);
-            this.panel_projectDataTable.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel_projectDataTable.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.panel_projectDataTable.Location = new System.Drawing.Point(0, 462);
-            this.panel_projectDataTable.Name = "panel_projectDataTable";
-            this.panel_projectDataTable.Size = new System.Drawing.Size(1006, 180);
-            this.panel_projectDataTable.TabIndex = 6;
+            panel_projectDataTable.Controls.Add(dataGridView_project);
+            panel_projectDataTable.Dock = System.Windows.Forms.DockStyle.Bottom;
+            panel_projectDataTable.ForeColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            panel_projectDataTable.Location = new System.Drawing.Point(0, 462);
+            panel_projectDataTable.Name = "panel_projectDataTable";
+            panel_projectDataTable.Size = new System.Drawing.Size(1006, 180);
+            panel_projectDataTable.TabIndex = 6;
             // 
             // dataGridView_project
             // 
-            this.dataGridView_project.BackgroundColor = System.Drawing.Color.DarkGray;
-            this.dataGridView_project.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.dataGridView_project.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dataGridView_project.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.dataGridView_project.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.dataGridView_project.Location = new System.Drawing.Point(0, 0);
-            this.dataGridView_project.Name = "dataGridView_project";
-            this.dataGridView_project.RowHeadersWidth = 62;
-            this.dataGridView_project.Size = new System.Drawing.Size(1006, 180);
-            this.dataGridView_project.TabIndex = 0;
+            dataGridView_project.BackgroundColor = System.Drawing.Color.DarkGray;
+            dataGridView_project.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            dataGridView_project.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            dataGridView_project.Dock = System.Windows.Forms.DockStyle.Bottom;
+            dataGridView_project.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold);
+            dataGridView_project.Location = new System.Drawing.Point(0, 0);
+            dataGridView_project.Name = "dataGridView_project";
+            dataGridView_project.RowHeadersWidth = 62;
+            dataGridView_project.Size = new System.Drawing.Size(1006, 180);
+            dataGridView_project.TabIndex = 0;
             // 
             // panel_projectMessage
             // 
-            this.panel_projectMessage.Controls.Add(this.textBox_projectImportMessages);
-            this.panel_projectMessage.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel_projectMessage.Location = new System.Drawing.Point(0, 278);
-            this.panel_projectMessage.Name = "panel_projectMessage";
-            this.panel_projectMessage.Size = new System.Drawing.Size(1006, 184);
-            this.panel_projectMessage.TabIndex = 10;
+            panel_projectMessage.Controls.Add(textBox_projectImportMessages);
+            panel_projectMessage.Dock = System.Windows.Forms.DockStyle.Bottom;
+            panel_projectMessage.Location = new System.Drawing.Point(0, 278);
+            panel_projectMessage.Name = "panel_projectMessage";
+            panel_projectMessage.Size = new System.Drawing.Size(1006, 184);
+            panel_projectMessage.TabIndex = 10;
             // 
             // textBox_projectImportMessages
             // 
-            this.textBox_projectImportMessages.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
-            this.textBox_projectImportMessages.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.textBox_projectImportMessages.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.textBox_projectImportMessages.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.textBox_projectImportMessages.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.textBox_projectImportMessages.Location = new System.Drawing.Point(0, 0);
-            this.textBox_projectImportMessages.Multiline = true;
-            this.textBox_projectImportMessages.Name = "textBox_projectImportMessages";
-            this.textBox_projectImportMessages.ReadOnly = true;
-            this.textBox_projectImportMessages.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.textBox_projectImportMessages.Size = new System.Drawing.Size(1006, 184);
-            this.textBox_projectImportMessages.TabIndex = 0;
-            this.textBox_projectImportMessages.WordWrap = false;
-            this.defaultToolTip.SetToolTip(this.textBox_projectImportMessages, "Validation or import status");
-            this.textBox_projectImportMessages.MouseClick += textBox_projectImportMessages_MouseClick;
+            textBox_projectImportMessages.BackColor = System.Drawing.Color.FromArgb(224, 224, 224);
+            textBox_projectImportMessages.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            textBox_projectImportMessages.Dock = System.Windows.Forms.DockStyle.Bottom;
+            textBox_projectImportMessages.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold);
+            textBox_projectImportMessages.ForeColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            textBox_projectImportMessages.Location = new System.Drawing.Point(0, 0);
+            textBox_projectImportMessages.Multiline = true;
+            textBox_projectImportMessages.Name = "textBox_projectImportMessages";
+            textBox_projectImportMessages.ReadOnly = true;
+            textBox_projectImportMessages.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            textBox_projectImportMessages.Size = new System.Drawing.Size(1006, 184);
+            textBox_projectImportMessages.TabIndex = 0;
+            defaultToolTip.SetToolTip(textBox_projectImportMessages, "Validation or import status");
+            textBox_projectImportMessages.WordWrap = false;
+            textBox_projectImportMessages.MouseClick += textBox_projectImportMessages_MouseClick;
             // 
             // panel_projectButtons
             // 
-            this.panel_projectButtons.Controls.Add(this.button_clear);
-            this.panel_projectButtons.Controls.Add(this.button_import);
-            this.panel_projectButtons.Controls.Add(this.button_validate);
-            this.panel_projectButtons.Controls.Add(this.button_stop);
-            this.panel_projectButtons.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel_projectButtons.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.panel_projectButtons.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.panel_projectButtons.Location = new System.Drawing.Point(0, 226);
-            this.panel_projectButtons.Name = "panel_projectButtons";
-            this.panel_projectButtons.Size = new System.Drawing.Size(1006, 52);
-            this.panel_projectButtons.TabIndex = 12;
+            panel_projectButtons.Controls.Add(button_clear);
+            panel_projectButtons.Controls.Add(button_import);
+            panel_projectButtons.Controls.Add(button_validate);
+            panel_projectButtons.Controls.Add(button_stop);
+            panel_projectButtons.Dock = System.Windows.Forms.DockStyle.Bottom;
+            panel_projectButtons.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold);
+            panel_projectButtons.ForeColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            panel_projectButtons.Location = new System.Drawing.Point(0, 226);
+            panel_projectButtons.Name = "panel_projectButtons";
+            panel_projectButtons.Size = new System.Drawing.Size(1006, 52);
+            panel_projectButtons.TabIndex = 12;
             // 
             // button_clear
             // 
-            this.button_clear.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.button_clear.BackColor = System.Drawing.Color.DimGray;
-            this.button_clear.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_clear.FlatAppearance.BorderSize = 0;
-            this.button_clear.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_clear.ForeColor = System.Drawing.Color.White;
-            this.button_clear.Location = new System.Drawing.Point(14, 12);
-            this.button_clear.Name = "button_clear";
-            this.button_clear.Size = new System.Drawing.Size(80, 29);
-            this.button_clear.TabIndex = 12;
-            this.button_clear.Text = "Reset All";
-            this.defaultToolTip.SetToolTip(this.button_clear, "Reset everything and reload data from TLP");
-            this.button_clear.UseVisualStyleBackColor = false;
-            this.button_clear.Click += button_clear_Click;
+            button_clear.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            button_clear.BackColor = System.Drawing.Color.DimGray;
+            button_clear.Cursor = System.Windows.Forms.Cursors.Hand;
+            button_clear.FlatAppearance.BorderSize = 0;
+            button_clear.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            button_clear.ForeColor = System.Drawing.Color.White;
+            button_clear.Location = new System.Drawing.Point(14, 12);
+            button_clear.Name = "button_clear";
+            button_clear.Size = new System.Drawing.Size(80, 29);
+            button_clear.TabIndex = 12;
+            button_clear.Text = "Reset All";
+            defaultToolTip.SetToolTip(button_clear, "Reset everything and reload data from TLP");
+            button_clear.UseVisualStyleBackColor = false;
+            button_clear.Click += button_clear_Click;
             // 
             // button_import
             // 
-            this.button_import.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.button_import.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(43)))), ((int)(((byte)(141)))));
-            this.button_import.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_import.FlatAppearance.BorderSize = 0;
-            this.button_import.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_import.ForeColor = System.Drawing.Color.White;
-            this.button_import.Location = new System.Drawing.Point(917, 12);
-            this.button_import.Name = "button_import";
-            this.button_import.Size = new System.Drawing.Size(80, 29);
-            this.button_import.TabIndex = 7;
-            this.button_import.Text = "Import";
-            this.defaultToolTip.SetToolTip(this.button_import, "Import all data");
-            this.button_import.UseVisualStyleBackColor = false;
-            this.button_import.Click += button_import_Click;
+            button_import.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            button_import.BackColor = System.Drawing.Color.FromArgb(226, 43, 141);
+            button_import.Cursor = System.Windows.Forms.Cursors.Hand;
+            button_import.FlatAppearance.BorderSize = 0;
+            button_import.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            button_import.ForeColor = System.Drawing.Color.White;
+            button_import.Location = new System.Drawing.Point(917, 12);
+            button_import.Name = "button_import";
+            button_import.Size = new System.Drawing.Size(80, 29);
+            button_import.TabIndex = 7;
+            button_import.Text = "Import";
+            defaultToolTip.SetToolTip(button_import, "Import all data");
+            button_import.UseVisualStyleBackColor = false;
+            button_import.Click += button_import_Click;
             // 
             // button_validate
             // 
-            this.button_validate.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.button_validate.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(43)))), ((int)(((byte)(141)))));
-            this.button_validate.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_validate.FlatAppearance.BorderSize = 0;
-            this.button_validate.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_validate.ForeColor = System.Drawing.Color.White;
-            this.button_validate.Location = new System.Drawing.Point(745, 12);
-            this.button_validate.Name = "button_validate";
-            this.button_validate.Size = new System.Drawing.Size(80, 29);
-            this.button_validate.TabIndex = 8;
-            this.button_validate.Text = "Validate";
-            this.defaultToolTip.SetToolTip(this.button_validate, "Validate data input before importing data");
-            this.button_validate.UseVisualStyleBackColor = false;
-            this.button_validate.Click += button_validate_Click;
+            button_validate.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            button_validate.BackColor = System.Drawing.Color.FromArgb(226, 43, 141);
+            button_validate.Cursor = System.Windows.Forms.Cursors.Hand;
+            button_validate.FlatAppearance.BorderSize = 0;
+            button_validate.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            button_validate.ForeColor = System.Drawing.Color.White;
+            button_validate.Location = new System.Drawing.Point(745, 12);
+            button_validate.Name = "button_validate";
+            button_validate.Size = new System.Drawing.Size(80, 29);
+            button_validate.TabIndex = 8;
+            button_validate.Text = "Validate";
+            defaultToolTip.SetToolTip(button_validate, "Validate data input before importing data");
+            button_validate.UseVisualStyleBackColor = false;
+            button_validate.Click += button_validate_Click;
             // 
             // button_stop
             // 
-            this.button_stop.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.button_stop.BackColor = System.Drawing.Color.DimGray;
-            this.button_stop.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_stop.FlatAppearance.BorderSize = 0;
-            this.button_stop.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_stop.ForeColor = System.Drawing.Color.White;
-            this.button_stop.Location = new System.Drawing.Point(831, 12);
-            this.button_stop.Name = "button_stop";
-            this.button_stop.Size = new System.Drawing.Size(80, 29);
-            this.button_stop.TabIndex = 11;
-            this.button_stop.Text = "Stop";
-            this.defaultToolTip.SetToolTip(this.button_stop, "Stop validation or import");
-            this.button_stop.UseVisualStyleBackColor = false;
-            this.button_stop.Click += button_stop_Click;
+            button_stop.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            button_stop.BackColor = System.Drawing.Color.DimGray;
+            button_stop.Cursor = System.Windows.Forms.Cursors.Hand;
+            button_stop.FlatAppearance.BorderSize = 0;
+            button_stop.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            button_stop.ForeColor = System.Drawing.Color.White;
+            button_stop.Location = new System.Drawing.Point(831, 12);
+            button_stop.Name = "button_stop";
+            button_stop.Size = new System.Drawing.Size(80, 29);
+            button_stop.TabIndex = 11;
+            button_stop.Text = "Stop";
+            defaultToolTip.SetToolTip(button_stop, "Stop validation or import");
+            button_stop.UseVisualStyleBackColor = false;
+            button_stop.Click += button_stop_Click;
             // 
             // panel_projectFieldMapping
             // 
-            this.panel_projectFieldMapping.AutoScroll = true;
-            this.panel_projectFieldMapping.Controls.Add(this.flowLayoutPanel_nonMandatoryFields);
-            this.panel_projectFieldMapping.Controls.Add(this.label_delimiter);
-            this.panel_projectFieldMapping.Controls.Add(this.comboBox_delimiter);
-            this.panel_projectFieldMapping.Controls.Add(this.groupBox_projectMandatoryFields);
-            this.panel_projectFieldMapping.Controls.Add(this.label_projectSetup);
-            this.panel_projectFieldMapping.Controls.Add(this.button_projectSelectFile);
-            this.panel_projectFieldMapping.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel_projectFieldMapping.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.panel_projectFieldMapping.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.panel_projectFieldMapping.Location = new System.Drawing.Point(0, 0);
-            this.panel_projectFieldMapping.Name = "panel_projectFieldMapping";
-            this.panel_projectFieldMapping.Size = new System.Drawing.Size(1006, 226);
-            this.panel_projectFieldMapping.TabIndex = 13;
+            panel_projectFieldMapping.AutoScroll = true;
+            panel_projectFieldMapping.Controls.Add(flowLayoutPanel_nonMandatoryFields);
+            panel_projectFieldMapping.Controls.Add(label_delimiter);
+            panel_projectFieldMapping.Controls.Add(comboBox_delimiter);
+            panel_projectFieldMapping.Controls.Add(groupBox_projectMandatoryFields);
+            panel_projectFieldMapping.Controls.Add(label_projectSetup);
+            panel_projectFieldMapping.Controls.Add(button_projectSelectFile);
+            panel_projectFieldMapping.Dock = System.Windows.Forms.DockStyle.Fill;
+            panel_projectFieldMapping.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold);
+            panel_projectFieldMapping.ForeColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            panel_projectFieldMapping.Location = new System.Drawing.Point(0, 0);
+            panel_projectFieldMapping.Name = "panel_projectFieldMapping";
+            panel_projectFieldMapping.Size = new System.Drawing.Size(1006, 226);
+            panel_projectFieldMapping.TabIndex = 13;
             // 
             // flowLayoutPanel_nonMandatoryFields
             // 
-            this.flowLayoutPanel_nonMandatoryFields.Controls.Add(this.panel_NonMandatoryButton);
-            this.flowLayoutPanel_nonMandatoryFields.Controls.Add(this.panel_NonMandatoryFields);
-            this.flowLayoutPanel_nonMandatoryFields.Location = new System.Drawing.Point(589, 60);
-            this.flowLayoutPanel_nonMandatoryFields.Name = "flowLayoutPanel_nonMandatoryFields";
-            this.flowLayoutPanel_nonMandatoryFields.Size = new System.Drawing.Size(372, 279);
-            this.flowLayoutPanel_nonMandatoryFields.TabIndex = 7;
+            flowLayoutPanel_nonMandatoryFields.Controls.Add(panel_NonMandatoryButton);
+            flowLayoutPanel_nonMandatoryFields.Controls.Add(panel_NonMandatoryFields);
+            flowLayoutPanel_nonMandatoryFields.Location = new System.Drawing.Point(589, 60);
+            flowLayoutPanel_nonMandatoryFields.Name = "flowLayoutPanel_nonMandatoryFields";
+            flowLayoutPanel_nonMandatoryFields.Size = new System.Drawing.Size(372, 279);
+            flowLayoutPanel_nonMandatoryFields.TabIndex = 7;
             // 
             // panel_NonMandatoryButton
             // 
-            this.panel_NonMandatoryButton.Controls.Add(this.label_nonMandatoryFields);
-            this.panel_NonMandatoryButton.Controls.Add(this.button_expandNonMandatory);
-            this.panel_NonMandatoryButton.Location = new System.Drawing.Point(3, 3);
-            this.panel_NonMandatoryButton.Name = "panel_NonMandatoryButton";
-            this.panel_NonMandatoryButton.Size = new System.Drawing.Size(363, 32);
-            this.panel_NonMandatoryButton.TabIndex = 0;
+            panel_NonMandatoryButton.Controls.Add(label_nonMandatoryFields);
+            panel_NonMandatoryButton.Controls.Add(button_expandNonMandatory);
+            panel_NonMandatoryButton.Location = new System.Drawing.Point(3, 3);
+            panel_NonMandatoryButton.Name = "panel_NonMandatoryButton";
+            panel_NonMandatoryButton.Size = new System.Drawing.Size(363, 32);
+            panel_NonMandatoryButton.TabIndex = 0;
             // 
             // label_nonMandatoryFields
             // 
-            this.label_nonMandatoryFields.AutoSize = true;
-            this.label_nonMandatoryFields.ForeColor = System.Drawing.Color.Black;
-            this.label_nonMandatoryFields.Location = new System.Drawing.Point(46, 8);
-            this.label_nonMandatoryFields.Name = "label_nonMandatoryFields";
-            this.label_nonMandatoryFields.Size = new System.Drawing.Size(107, 17);
-            this.label_nonMandatoryFields.TabIndex = 1;
-            this.label_nonMandatoryFields.Text = "Non-Mandatory";
+            label_nonMandatoryFields.AutoSize = true;
+            label_nonMandatoryFields.ForeColor = System.Drawing.Color.Black;
+            label_nonMandatoryFields.Location = new System.Drawing.Point(46, 8);
+            label_nonMandatoryFields.Name = "label_nonMandatoryFields";
+            label_nonMandatoryFields.Size = new System.Drawing.Size(107, 17);
+            label_nonMandatoryFields.TabIndex = 1;
+            label_nonMandatoryFields.Text = "Non-Mandatory";
             // 
             // button_expandNonMandatory
             // 
-            this.button_expandNonMandatory.BackColor = System.Drawing.Color.White;
-            this.button_expandNonMandatory.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button_expandNonMandatory.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_expandNonMandatory.FlatAppearance.BorderSize = 0;
-            this.button_expandNonMandatory.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_expandNonMandatory.ForeColor = System.Drawing.Color.White;
-            this.button_expandNonMandatory.Location = new System.Drawing.Point(10, 1);
-            this.button_expandNonMandatory.Name = "button_expandNonMandatory";
-            this.button_expandNonMandatory.Size = new System.Drawing.Size(30, 30);
-            this.button_expandNonMandatory.TabIndex = 0;
-            this.button_expandNonMandatory.UseVisualStyleBackColor = false;
-            this.button_expandNonMandatory.Click += button_expand_Click;
+            button_expandNonMandatory.BackColor = System.Drawing.Color.White;
+            button_expandNonMandatory.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            button_expandNonMandatory.Cursor = System.Windows.Forms.Cursors.Hand;
+            button_expandNonMandatory.FlatAppearance.BorderSize = 0;
+            button_expandNonMandatory.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            button_expandNonMandatory.ForeColor = System.Drawing.Color.White;
+            button_expandNonMandatory.Location = new System.Drawing.Point(10, 1);
+            button_expandNonMandatory.Name = "button_expandNonMandatory";
+            button_expandNonMandatory.Size = new System.Drawing.Size(30, 30);
+            button_expandNonMandatory.TabIndex = 0;
+            button_expandNonMandatory.UseVisualStyleBackColor = false;
+            button_expandNonMandatory.Click += button_expand_Click;
             // 
             // panel_NonMandatoryFields
             // 
-            this.panel_NonMandatoryFields.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_customerInvRef);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_customerInvRef);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_contactPerson);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_contactPerson);
-            this.panel_NonMandatoryFields.Controls.Add(this.checkBox_defaultProjectCategory);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_projectNo);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_projectNo);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_projectCategory);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_description);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_projectCategory);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_description);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_projectStartDate);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_projectStartDate);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_projectEndDate);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_projectEndDate);
-            this.panel_NonMandatoryFields.Location = new System.Drawing.Point(3, 41);
-            this.panel_NonMandatoryFields.MaximumSize = new System.Drawing.Size(363, 225);
-            this.panel_NonMandatoryFields.MinimumSize = new System.Drawing.Size(363, 0);
-            this.panel_NonMandatoryFields.Name = "panel_NonMandatoryFields";
-            this.panel_NonMandatoryFields.Size = new System.Drawing.Size(363, 225);
-            this.panel_NonMandatoryFields.TabIndex = 1;
-            // 
-            // comboBox_contactPerson
-            // 
-            this.comboBox_contactPerson.FormattingEnabled = true;
-            this.comboBox_contactPerson.Location = new System.Drawing.Point(153, 162);
-            this.comboBox_contactPerson.Name = "comboBox_contactPerson";
-            this.comboBox_contactPerson.Size = new System.Drawing.Size(139, 25);
-            this.comboBox_contactPerson.TabIndex = 7;
-            // 
-            // label_contactPerson
-            // 
-            this.label_contactPerson.AutoSize = true;
-            this.label_contactPerson.Location = new System.Drawing.Point(10, 168);
-            this.label_contactPerson.Name = "label_contactPerson";
-            this.label_contactPerson.Size = new System.Drawing.Size(145, 17);
-            this.label_contactPerson.TabIndex = 6;
-            this.label_contactPerson.Text = "Contact Person (email)";
-            // 
-            // checkBox_defaultProjectCategory
-            // 
-            this.checkBox_defaultProjectCategory.AutoSize = true;
-            this.checkBox_defaultProjectCategory.Font = new System.Drawing.Font("Segoe UI Semibold", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.checkBox_defaultProjectCategory.Location = new System.Drawing.Point(293, 133);
-            this.checkBox_defaultProjectCategory.MaximumSize = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultProjectCategory.Name = "checkBox_defaultProjectCategory";
-            this.checkBox_defaultProjectCategory.Size = new System.Drawing.Size(65, 19);
-            this.checkBox_defaultProjectCategory.TabIndex = 5;
-            this.checkBox_defaultProjectCategory.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultProjectCategory, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultProjectCategory.UseVisualStyleBackColor = true;
-            this.checkBox_defaultProjectCategory.CheckedChanged += checkBox_defaultProjectCategory_CheckedChanged;
-            // 
-            // label_projectNo
-            // 
-            this.label_projectNo.AutoSize = true;
-            this.label_projectNo.Location = new System.Drawing.Point(10, 10);
-            this.label_projectNo.Name = "label_projectNo";
-            this.label_projectNo.Size = new System.Drawing.Size(72, 17);
-            this.label_projectNo.TabIndex = 1;
-            this.label_projectNo.Text = "Project No";
-            // 
-            // comboBox_projectNo
-            // 
-            this.comboBox_projectNo.FormattingEnabled = true;
-            this.comboBox_projectNo.Location = new System.Drawing.Point(153, 7);
-            this.comboBox_projectNo.Name = "comboBox_projectNo";
-            this.comboBox_projectNo.Size = new System.Drawing.Size(139, 25);
-            this.comboBox_projectNo.TabIndex = 3;
-            // 
-            // label_projectCategory
-            // 
-            this.label_projectCategory.AutoSize = true;
-            this.label_projectCategory.Location = new System.Drawing.Point(10, 134);
-            this.label_projectCategory.Name = "label_projectCategory";
-            this.label_projectCategory.Size = new System.Drawing.Size(110, 17);
-            this.label_projectCategory.TabIndex = 1;
-            this.label_projectCategory.Text = "Project Category";
-            // 
-            // comboBox_description
-            // 
-            this.comboBox_description.FormattingEnabled = true;
-            this.comboBox_description.Location = new System.Drawing.Point(153, 38);
-            this.comboBox_description.Name = "comboBox_description";
-            this.comboBox_description.Size = new System.Drawing.Size(139, 25);
-            this.comboBox_description.TabIndex = 3;
-            // 
-            // comboBox_projectCategory
-            // 
-            this.comboBox_projectCategory.FormattingEnabled = true;
-            this.comboBox_projectCategory.Location = new System.Drawing.Point(153, 131);
-            this.comboBox_projectCategory.Name = "comboBox_projectCategory";
-            this.comboBox_projectCategory.Size = new System.Drawing.Size(139, 25);
-            this.comboBox_projectCategory.TabIndex = 3;
-            // 
-            // label_description
-            // 
-            this.label_description.AutoSize = true;
-            this.label_description.Location = new System.Drawing.Point(10, 41);
-            this.label_description.Name = "label_description";
-            this.label_description.Size = new System.Drawing.Size(76, 17);
-            this.label_description.TabIndex = 1;
-            this.label_description.Text = "Description";
-            // 
-            // comboBox_projectStartDate
-            // 
-            this.comboBox_projectStartDate.FormattingEnabled = true;
-            this.comboBox_projectStartDate.Location = new System.Drawing.Point(153, 69);
-            this.comboBox_projectStartDate.Name = "comboBox_projectStartDate";
-            this.comboBox_projectStartDate.Size = new System.Drawing.Size(139, 25);
-            this.comboBox_projectStartDate.TabIndex = 3;
-            // 
-            // label_projectStartDate
-            // 
-            this.label_projectStartDate.AutoSize = true;
-            this.label_projectStartDate.Location = new System.Drawing.Point(10, 72);
-            this.label_projectStartDate.Name = "label_projectStartDate";
-            this.label_projectStartDate.Size = new System.Drawing.Size(115, 17);
-            this.label_projectStartDate.TabIndex = 1;
-            this.label_projectStartDate.Text = "Project Start Date";
-            // 
-            // label_projectEndDate
-            // 
-            this.label_projectEndDate.AutoSize = true;
-            this.label_projectEndDate.Location = new System.Drawing.Point(10, 103);
-            this.label_projectEndDate.Name = "label_projectEndDate";
-            this.label_projectEndDate.Size = new System.Drawing.Size(109, 17);
-            this.label_projectEndDate.TabIndex = 1;
-            this.label_projectEndDate.Text = "Project End Date";
-            // 
-            // comboBox_projectEndDate
-            // 
-            this.comboBox_projectEndDate.FormattingEnabled = true;
-            this.comboBox_projectEndDate.Location = new System.Drawing.Point(153, 100);
-            this.comboBox_projectEndDate.Name = "comboBox_projectEndDate";
-            this.comboBox_projectEndDate.Size = new System.Drawing.Size(139, 25);
-            this.comboBox_projectEndDate.TabIndex = 3;
-            // 
-            // label_delimiter
-            // 
-            this.label_delimiter.AutoSize = true;
-            this.label_delimiter.Location = new System.Drawing.Point(10, 75);
-            this.label_delimiter.Name = "label_delimiter";
-            this.label_delimiter.Size = new System.Drawing.Size(62, 17);
-            this.label_delimiter.TabIndex = 1;
-            this.label_delimiter.Text = "Delimiter";
-            // 
-            // comboBox_delimiter
-            // 
-            this.comboBox_delimiter.FormattingEnabled = true;
-            this.comboBox_delimiter.Location = new System.Drawing.Point(82, 72);
-            this.comboBox_delimiter.Name = "comboBox_delimiter";
-            this.comboBox_delimiter.Size = new System.Drawing.Size(56, 25);
-            this.comboBox_delimiter.TabIndex = 6;
-            // 
-            // groupBox_projectMandatoryFields
-            // 
-            this.groupBox_projectMandatoryFields.Controls.Add(this.checkBox_defaultProjectDepartment);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.label_projectDepartment);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.comboBox_projectDepartment);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.checkBox_defaultLegalEntity);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.checkBox_defaultProjectTemplate);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.checkBox_defaultProjectType);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.checkBox_defaultCurrencyISO);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.label_projectLegalEntity);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.comboBox_projectLegalEntity);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.label_projectCurrencyISO);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.label_projectType);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.comboBox_projectCurrencyISO);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.label_projectManager);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.comboBox_projectManager);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.label_projectTemplate);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.comboBox_projectType);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.comboBox_projectTemplate);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.label_projectCustomerNo);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.comboBox_projectCustomerNo);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.label_projectName);
-            this.groupBox_projectMandatoryFields.Controls.Add(this.comboBox_projectName);
-            this.groupBox_projectMandatoryFields.Location = new System.Drawing.Point(184, 62);
-            this.groupBox_projectMandatoryFields.Name = "groupBox_projectMandatoryFields";
-            this.groupBox_projectMandatoryFields.Size = new System.Drawing.Size(358, 277);
-            this.groupBox_projectMandatoryFields.TabIndex = 5;
-            this.groupBox_projectMandatoryFields.TabStop = false;
-            this.groupBox_projectMandatoryFields.Text = "Mandatory";
-            // 
-            // checkBox_defaultProjectDepartment
-            // 
-            this.checkBox_defaultProjectDepartment.AutoSize = true;
-            this.checkBox_defaultProjectDepartment.Location = new System.Drawing.Point(283, 243);
-            this.checkBox_defaultProjectDepartment.Name = "checkBox_defaultProjectDepartment";
-            this.checkBox_defaultProjectDepartment.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultProjectDepartment.TabIndex = 9;
-            this.checkBox_defaultProjectDepartment.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultProjectDepartment, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultProjectDepartment.UseVisualStyleBackColor = true;
-            this.checkBox_defaultProjectDepartment.CheckedChanged += checkBox_defaultProjectDepartment_CheckedChanged;
-            // 
-            // label_projectDepartment
-            // 
-            this.label_projectDepartment.AutoSize = true;
-            this.label_projectDepartment.Location = new System.Drawing.Point(6, 244);
-            this.label_projectDepartment.Name = "label_projectDepartment";
-            this.label_projectDepartment.Size = new System.Drawing.Size(121, 17);
-            this.label_projectDepartment.TabIndex = 7;
-            this.label_projectDepartment.Text = "Department Name";
-            // 
-            // comboBox_projectDepartment
-            // 
-            this.comboBox_projectDepartment.FormattingEnabled = true;
-            this.comboBox_projectDepartment.Location = new System.Drawing.Point(138, 241);
-            this.comboBox_projectDepartment.Name = "comboBox_projectDepartment";
-            this.comboBox_projectDepartment.Size = new System.Drawing.Size(139, 25);
-            this.comboBox_projectDepartment.TabIndex = 8;
-            // 
-            // checkBox_defaultLegalEntity
-            // 
-            this.checkBox_defaultLegalEntity.AutoSize = true;
-            this.checkBox_defaultLegalEntity.Location = new System.Drawing.Point(283, 181);
-            this.checkBox_defaultLegalEntity.Name = "checkBox_defaultLegalEntity";
-            this.checkBox_defaultLegalEntity.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultLegalEntity.TabIndex = 6;
-            this.checkBox_defaultLegalEntity.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultLegalEntity, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultLegalEntity.UseVisualStyleBackColor = true;
-            this.checkBox_defaultLegalEntity.CheckedChanged += checkBox_defaultLegalEntity_CheckedChanged;
-            // 
-            // checkBox_defaultProjectTemplate
-            // 
-            this.checkBox_defaultProjectTemplate.AutoSize = true;
-            this.checkBox_defaultProjectTemplate.Location = new System.Drawing.Point(283, 88);
-            this.checkBox_defaultProjectTemplate.Name = "checkBox_defaultProjectTemplate";
-            this.checkBox_defaultProjectTemplate.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultProjectTemplate.TabIndex = 5;
-            this.checkBox_defaultProjectTemplate.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultProjectTemplate, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultProjectTemplate.UseVisualStyleBackColor = true;
-            this.checkBox_defaultProjectTemplate.CheckedChanged += checkBox_defaultProjectTemplate_CheckedChanged;
-
-            // 
-            // checkBox_defaultProjectType
-            // 
-            this.checkBox_defaultProjectType.AutoSize = true;
-            this.checkBox_defaultProjectType.Location = new System.Drawing.Point(283, 212);
-            this.checkBox_defaultProjectType.Name = "checkBox_defaultProjectType";
-            this.checkBox_defaultProjectType.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultProjectType.TabIndex = 4;
-            this.checkBox_defaultProjectType.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultProjectType, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultProjectType.UseVisualStyleBackColor = true;
-            this.checkBox_defaultProjectType.CheckedChanged += checkBox_defaultProjectType_CheckedChanged;
-            // 
-            // checkBox_defaultCurrencyISO
-            // 
-            this.checkBox_defaultCurrencyISO.AutoSize = true;
-            this.checkBox_defaultCurrencyISO.Location = new System.Drawing.Point(283, 150);
-            this.checkBox_defaultCurrencyISO.Name = "checkBox_defaultCurrencyISO";
-            this.checkBox_defaultCurrencyISO.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultCurrencyISO.TabIndex = 4;
-            this.checkBox_defaultCurrencyISO.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultCurrencyISO, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultCurrencyISO.UseVisualStyleBackColor = true;
-            this.checkBox_defaultCurrencyISO.CheckedChanged += checkBox_defaultCurrencyISO_CheckedChanged;
-            
-            // 
-            // label_projectLegalEntity
-            // 
-            this.label_projectLegalEntity.AutoSize = true;
-            this.label_projectLegalEntity.Location = new System.Drawing.Point(6, 182);
-            this.label_projectLegalEntity.Name = "label_projectLegalEntity";
-            this.label_projectLegalEntity.Size = new System.Drawing.Size(78, 17);
-            this.label_projectLegalEntity.TabIndex = 1;
-            this.label_projectLegalEntity.Text = "Legal Entity";
-            // 
-            // comboBox_projectLegalEntity
-            // 
-            this.comboBox_projectLegalEntity.FormattingEnabled = true;
-            this.comboBox_projectLegalEntity.Location = new System.Drawing.Point(138, 179);
-            this.comboBox_projectLegalEntity.Name = "comboBox_projectLegalEntity";
-            this.comboBox_projectLegalEntity.Size = new System.Drawing.Size(139, 25);
-            this.comboBox_projectLegalEntity.TabIndex = 3;
-            // 
-            // label_projectCurrencyISO
-            // 
-            this.label_projectCurrencyISO.AutoSize = true;
-            this.label_projectCurrencyISO.Location = new System.Drawing.Point(6, 151);
-            this.label_projectCurrencyISO.Name = "label_projectCurrencyISO";
-            this.label_projectCurrencyISO.Size = new System.Drawing.Size(87, 17);
-            this.label_projectCurrencyISO.TabIndex = 1;
-            this.label_projectCurrencyISO.Text = "Currency ISO";
-            // 
-            // label_projectType
-            // 
-            this.label_projectType.AutoSize = true;
-            this.label_projectType.Location = new System.Drawing.Point(6, 213);
-            this.label_projectType.Name = "label_projectType";
-            this.label_projectType.Size = new System.Drawing.Size(82, 17);
-            this.label_projectType.TabIndex = 1;
-            this.label_projectType.Text = "Project Type";
-            // 
-            // comboBox_projectCurrencyISO
-            // 
-            this.comboBox_projectCurrencyISO.FormattingEnabled = true;
-            this.comboBox_projectCurrencyISO.Location = new System.Drawing.Point(138, 148);
-            this.comboBox_projectCurrencyISO.Name = "comboBox_projectCurrencyISO";
-            this.comboBox_projectCurrencyISO.Size = new System.Drawing.Size(139, 25);
-            this.comboBox_projectCurrencyISO.TabIndex = 3;
-            // 
-            // label_projectManager
-            // 
-            this.label_projectManager.AutoSize = true;
-            this.label_projectManager.Location = new System.Drawing.Point(6, 120);
-            this.label_projectManager.Name = "label_projectManager";
-            this.label_projectManager.Size = new System.Drawing.Size(79, 17);
-            this.label_projectManager.TabIndex = 1;
-            this.label_projectManager.Text = "P. M. Initials";
-            // 
-            // comboBox_projectManager
-            // 
-            this.comboBox_projectManager.FormattingEnabled = true;
-            this.comboBox_projectManager.Location = new System.Drawing.Point(138, 117);
-            this.comboBox_projectManager.Name = "comboBox_projectManager";
-            this.comboBox_projectManager.Size = new System.Drawing.Size(139, 25);
-            this.comboBox_projectManager.TabIndex = 3;
-            // 
-            // label_projectTemplate
-            // 
-            this.label_projectTemplate.AutoSize = true;
-            this.label_projectTemplate.Location = new System.Drawing.Point(6, 89);
-            this.label_projectTemplate.Name = "label_projectTemplate";
-            this.label_projectTemplate.Size = new System.Drawing.Size(109, 17);
-            this.label_projectTemplate.TabIndex = 1;
-            this.label_projectTemplate.Text = "Project Template";
-            // 
-            // comboBox_projectType
-            // 
-            this.comboBox_projectType.FormattingEnabled = true;
-            this.comboBox_projectType.Location = new System.Drawing.Point(138, 210);
-            this.comboBox_projectType.Name = "comboBox_projectType";
-            this.comboBox_projectType.Size = new System.Drawing.Size(139, 25);
-            this.comboBox_projectType.TabIndex = 3;
-            // 
-            // comboBox_projectTemplate
-            // 
-            this.comboBox_projectTemplate.FormattingEnabled = true;
-            this.comboBox_projectTemplate.Location = new System.Drawing.Point(138, 86);
-            this.comboBox_projectTemplate.Name = "comboBox_projectTemplate";
-            this.comboBox_projectTemplate.Size = new System.Drawing.Size(139, 25);
-            this.comboBox_projectTemplate.TabIndex = 3;
-            // 
-            // label_projectCustomerNo
-            // 
-            this.label_projectCustomerNo.AutoSize = true;
-            this.label_projectCustomerNo.Location = new System.Drawing.Point(6, 58);
-            this.label_projectCustomerNo.Name = "label_projectCustomerNo";
-            this.label_projectCustomerNo.Size = new System.Drawing.Size(89, 17);
-            this.label_projectCustomerNo.TabIndex = 1;
-            this.label_projectCustomerNo.Text = "Customer No";
-            // 
-            // comboBox_projectCustomerNo
-            // 
-            this.comboBox_projectCustomerNo.FormattingEnabled = true;
-            this.comboBox_projectCustomerNo.Location = new System.Drawing.Point(138, 55);
-            this.comboBox_projectCustomerNo.Name = "comboBox_projectCustomerNo";
-            this.comboBox_projectCustomerNo.Size = new System.Drawing.Size(139, 25);
-            this.comboBox_projectCustomerNo.TabIndex = 3;
-            // 
-            // label_projectName
-            // 
-            this.label_projectName.AutoSize = true;
-            this.label_projectName.Location = new System.Drawing.Point(6, 27);
-            this.label_projectName.Name = "label_projectName";
-            this.label_projectName.Size = new System.Drawing.Size(90, 17);
-            this.label_projectName.TabIndex = 1;
-            this.label_projectName.Text = "Project Name";
-            // 
-            // comboBox_projectName
-            // 
-            this.comboBox_projectName.FormattingEnabled = true;
-            this.comboBox_projectName.Location = new System.Drawing.Point(138, 24);
-            this.comboBox_projectName.Name = "comboBox_projectName";
-            this.comboBox_projectName.Size = new System.Drawing.Size(139, 25);
-            this.comboBox_projectName.TabIndex = 3;
-            // 
-            // label_projectSetup
-            // 
-            this.label_projectSetup.AutoSize = true;
-            this.label_projectSetup.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.label_projectSetup.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.label_projectSetup.Location = new System.Drawing.Point(7, 16);
-            this.label_projectSetup.Name = "label_projectSetup";
-            this.label_projectSetup.Size = new System.Drawing.Size(231, 32);
-            this.label_projectSetup.TabIndex = 0;
-            this.label_projectSetup.Text = "Project Data Import";
-            // 
-            // button_projectSelectFile
-            // 
-            this.button_projectSelectFile.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(43)))), ((int)(((byte)(141)))));
-            this.button_projectSelectFile.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_projectSelectFile.FlatAppearance.BorderSize = 0;
-            this.button_projectSelectFile.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_projectSelectFile.ForeColor = System.Drawing.Color.White;
-            this.button_projectSelectFile.Location = new System.Drawing.Point(13, 111);
-            this.button_projectSelectFile.Name = "button_projectSelectFile";
-            this.button_projectSelectFile.Size = new System.Drawing.Size(80, 29);
-            this.button_projectSelectFile.TabIndex = 4;
-            this.button_projectSelectFile.Text = "Select File";
-            this.defaultToolTip.SetToolTip(this.button_projectSelectFile, "Select input CSV file");
-            this.button_projectSelectFile.UseVisualStyleBackColor = false;
-            this.button_projectSelectFile.Click += button_select_project_file_Click;
-            // 
-            // tmrExpand
-            // 
-            this.tmrExpand.Interval = 10;
-            this.tmrExpand.Tick += tmrExpand_Tick;
-            // 
-            // defaultToolTip
-            // 
-            this.defaultToolTip.ShowAlways = true;
+            panel_NonMandatoryFields.BackColor = System.Drawing.Color.FromArgb(224, 224, 224);
+            panel_NonMandatoryFields.Controls.Add(comboBox_customerInvRef);
+            panel_NonMandatoryFields.Controls.Add(label_customerInvRef);
+            panel_NonMandatoryFields.Controls.Add(comboBox_contactPerson);
+            panel_NonMandatoryFields.Controls.Add(label_contactPerson);
+            panel_NonMandatoryFields.Controls.Add(checkBox_defaultProjectCategory);
+            panel_NonMandatoryFields.Controls.Add(label_projectNo);
+            panel_NonMandatoryFields.Controls.Add(comboBox_projectNo);
+            panel_NonMandatoryFields.Controls.Add(label_projectCategory);
+            panel_NonMandatoryFields.Controls.Add(comboBox_description);
+            panel_NonMandatoryFields.Controls.Add(comboBox_projectCategory);
+            panel_NonMandatoryFields.Controls.Add(label_description);
+            panel_NonMandatoryFields.Controls.Add(comboBox_projectStartDate);
+            panel_NonMandatoryFields.Controls.Add(label_projectStartDate);
+            panel_NonMandatoryFields.Controls.Add(label_projectEndDate);
+            panel_NonMandatoryFields.Controls.Add(comboBox_projectEndDate);
+            panel_NonMandatoryFields.Location = new System.Drawing.Point(3, 41);
+            panel_NonMandatoryFields.MaximumSize = new System.Drawing.Size(363, 225);
+            panel_NonMandatoryFields.MinimumSize = new System.Drawing.Size(363, 0);
+            panel_NonMandatoryFields.Name = "panel_NonMandatoryFields";
+            panel_NonMandatoryFields.Size = new System.Drawing.Size(363, 225);
+            panel_NonMandatoryFields.TabIndex = 1;
             // 
             // comboBox_customerInvRef
             // 
-            this.comboBox_customerInvRef.FormattingEnabled = true;
-            this.comboBox_customerInvRef.Location = new System.Drawing.Point(153, 193);
-            this.comboBox_customerInvRef.Name = "comboBox_customerInvRef";
-            this.comboBox_customerInvRef.Size = new System.Drawing.Size(139, 25);
-            this.comboBox_customerInvRef.TabIndex = 9;
+            comboBox_customerInvRef.FormattingEnabled = true;
+            comboBox_customerInvRef.Location = new System.Drawing.Point(153, 193);
+            comboBox_customerInvRef.Name = "comboBox_customerInvRef";
+            comboBox_customerInvRef.Size = new System.Drawing.Size(139, 25);
+            comboBox_customerInvRef.TabIndex = 9;
             // 
             // label_customerInvRef
             // 
-            this.label_customerInvRef.AutoSize = true;
-            this.label_customerInvRef.Location = new System.Drawing.Point(10, 199);
-            this.label_customerInvRef.Name = "label_customerInvRef";
-            this.label_customerInvRef.Size = new System.Drawing.Size(117, 17);
-            this.label_customerInvRef.TabIndex = 8;
-            this.label_customerInvRef.Text = "Customer Inv. Ref.";
+            label_customerInvRef.AutoSize = true;
+            label_customerInvRef.Location = new System.Drawing.Point(10, 199);
+            label_customerInvRef.Name = "label_customerInvRef";
+            label_customerInvRef.Size = new System.Drawing.Size(117, 17);
+            label_customerInvRef.TabIndex = 8;
+            label_customerInvRef.Text = "Customer Inv. Ref.";
+            // 
+            // comboBox_contactPerson
+            // 
+            comboBox_contactPerson.FormattingEnabled = true;
+            comboBox_contactPerson.Location = new System.Drawing.Point(153, 162);
+            comboBox_contactPerson.Name = "comboBox_contactPerson";
+            comboBox_contactPerson.Size = new System.Drawing.Size(139, 25);
+            comboBox_contactPerson.TabIndex = 7;
+            // 
+            // label_contactPerson
+            // 
+            label_contactPerson.AutoSize = true;
+            label_contactPerson.Location = new System.Drawing.Point(10, 168);
+            label_contactPerson.Name = "label_contactPerson";
+            label_contactPerson.Size = new System.Drawing.Size(145, 17);
+            label_contactPerson.TabIndex = 6;
+            label_contactPerson.Text = "Contact Person (email)";
+            // 
+            // checkBox_defaultProjectCategory
+            // 
+            checkBox_defaultProjectCategory.AutoSize = true;
+            checkBox_defaultProjectCategory.Font = new System.Drawing.Font("Segoe UI Semibold", 9F, System.Drawing.FontStyle.Bold);
+            checkBox_defaultProjectCategory.Location = new System.Drawing.Point(293, 133);
+            checkBox_defaultProjectCategory.MaximumSize = new System.Drawing.Size(70, 21);
+            checkBox_defaultProjectCategory.Name = "checkBox_defaultProjectCategory";
+            checkBox_defaultProjectCategory.Size = new System.Drawing.Size(65, 19);
+            checkBox_defaultProjectCategory.TabIndex = 5;
+            checkBox_defaultProjectCategory.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultProjectCategory, "Set default values for all rows of a particular column field");
+            checkBox_defaultProjectCategory.UseVisualStyleBackColor = true;
+            checkBox_defaultProjectCategory.CheckedChanged += checkBox_defaultProjectCategory_CheckedChanged;
+            // 
+            // label_projectNo
+            // 
+            label_projectNo.AutoSize = true;
+            label_projectNo.Location = new System.Drawing.Point(10, 10);
+            label_projectNo.Name = "label_projectNo";
+            label_projectNo.Size = new System.Drawing.Size(72, 17);
+            label_projectNo.TabIndex = 1;
+            label_projectNo.Text = "Project No";
+            // 
+            // comboBox_projectNo
+            // 
+            comboBox_projectNo.FormattingEnabled = true;
+            comboBox_projectNo.Location = new System.Drawing.Point(153, 7);
+            comboBox_projectNo.Name = "comboBox_projectNo";
+            comboBox_projectNo.Size = new System.Drawing.Size(139, 25);
+            comboBox_projectNo.TabIndex = 3;
+            // 
+            // label_projectCategory
+            // 
+            label_projectCategory.AutoSize = true;
+            label_projectCategory.Location = new System.Drawing.Point(10, 134);
+            label_projectCategory.Name = "label_projectCategory";
+            label_projectCategory.Size = new System.Drawing.Size(110, 17);
+            label_projectCategory.TabIndex = 1;
+            label_projectCategory.Text = "Project Category";
+            // 
+            // comboBox_description
+            // 
+            comboBox_description.FormattingEnabled = true;
+            comboBox_description.Location = new System.Drawing.Point(153, 38);
+            comboBox_description.Name = "comboBox_description";
+            comboBox_description.Size = new System.Drawing.Size(139, 25);
+            comboBox_description.TabIndex = 3;
+            // 
+            // comboBox_projectCategory
+            // 
+            comboBox_projectCategory.FormattingEnabled = true;
+            comboBox_projectCategory.Location = new System.Drawing.Point(153, 131);
+            comboBox_projectCategory.Name = "comboBox_projectCategory";
+            comboBox_projectCategory.Size = new System.Drawing.Size(139, 25);
+            comboBox_projectCategory.TabIndex = 3;
+            // 
+            // label_description
+            // 
+            label_description.AutoSize = true;
+            label_description.Location = new System.Drawing.Point(10, 41);
+            label_description.Name = "label_description";
+            label_description.Size = new System.Drawing.Size(76, 17);
+            label_description.TabIndex = 1;
+            label_description.Text = "Description";
+            // 
+            // comboBox_projectStartDate
+            // 
+            comboBox_projectStartDate.FormattingEnabled = true;
+            comboBox_projectStartDate.Location = new System.Drawing.Point(153, 69);
+            comboBox_projectStartDate.Name = "comboBox_projectStartDate";
+            comboBox_projectStartDate.Size = new System.Drawing.Size(139, 25);
+            comboBox_projectStartDate.TabIndex = 3;
+            // 
+            // label_projectStartDate
+            // 
+            label_projectStartDate.AutoSize = true;
+            label_projectStartDate.Location = new System.Drawing.Point(10, 72);
+            label_projectStartDate.Name = "label_projectStartDate";
+            label_projectStartDate.Size = new System.Drawing.Size(115, 17);
+            label_projectStartDate.TabIndex = 1;
+            label_projectStartDate.Text = "Project Start Date";
+            // 
+            // label_projectEndDate
+            // 
+            label_projectEndDate.AutoSize = true;
+            label_projectEndDate.Location = new System.Drawing.Point(10, 103);
+            label_projectEndDate.Name = "label_projectEndDate";
+            label_projectEndDate.Size = new System.Drawing.Size(109, 17);
+            label_projectEndDate.TabIndex = 1;
+            label_projectEndDate.Text = "Project End Date";
+            // 
+            // comboBox_projectEndDate
+            // 
+            comboBox_projectEndDate.FormattingEnabled = true;
+            comboBox_projectEndDate.Location = new System.Drawing.Point(153, 100);
+            comboBox_projectEndDate.Name = "comboBox_projectEndDate";
+            comboBox_projectEndDate.Size = new System.Drawing.Size(139, 25);
+            comboBox_projectEndDate.TabIndex = 3;
+            // 
+            // label_delimiter
+            // 
+            label_delimiter.AutoSize = true;
+            label_delimiter.Location = new System.Drawing.Point(10, 75);
+            label_delimiter.Name = "label_delimiter";
+            label_delimiter.Size = new System.Drawing.Size(62, 17);
+            label_delimiter.TabIndex = 1;
+            label_delimiter.Text = "Delimiter";
+            // 
+            // comboBox_delimiter
+            // 
+            comboBox_delimiter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboBox_delimiter.FormattingEnabled = true;
+            comboBox_delimiter.Location = new System.Drawing.Point(82, 72);
+            comboBox_delimiter.Name = "comboBox_delimiter";
+            comboBox_delimiter.Size = new System.Drawing.Size(56, 25);
+            comboBox_delimiter.TabIndex = 6;
+            // 
+            // groupBox_projectMandatoryFields
+            // 
+            groupBox_projectMandatoryFields.Controls.Add(checkBox_defaultProjectDepartment);
+            groupBox_projectMandatoryFields.Controls.Add(label_projectDepartment);
+            groupBox_projectMandatoryFields.Controls.Add(comboBox_projectDepartment);
+            groupBox_projectMandatoryFields.Controls.Add(checkBox_defaultLegalEntity);
+            groupBox_projectMandatoryFields.Controls.Add(checkBox_defaultProjectTemplate);
+            groupBox_projectMandatoryFields.Controls.Add(checkBox_defaultProjectType);
+            groupBox_projectMandatoryFields.Controls.Add(checkBox_defaultCurrencyISO);
+            groupBox_projectMandatoryFields.Controls.Add(label_projectLegalEntity);
+            groupBox_projectMandatoryFields.Controls.Add(comboBox_projectLegalEntity);
+            groupBox_projectMandatoryFields.Controls.Add(label_projectCurrencyISO);
+            groupBox_projectMandatoryFields.Controls.Add(label_projectType);
+            groupBox_projectMandatoryFields.Controls.Add(comboBox_projectCurrencyISO);
+            groupBox_projectMandatoryFields.Controls.Add(label_projectManager);
+            groupBox_projectMandatoryFields.Controls.Add(comboBox_projectManager);
+            groupBox_projectMandatoryFields.Controls.Add(label_projectTemplate);
+            groupBox_projectMandatoryFields.Controls.Add(comboBox_projectType);
+            groupBox_projectMandatoryFields.Controls.Add(comboBox_projectTemplate);
+            groupBox_projectMandatoryFields.Controls.Add(label_projectCustomerNo);
+            groupBox_projectMandatoryFields.Controls.Add(comboBox_projectCustomerNo);
+            groupBox_projectMandatoryFields.Controls.Add(label_projectName);
+            groupBox_projectMandatoryFields.Controls.Add(comboBox_projectName);
+            groupBox_projectMandatoryFields.Location = new System.Drawing.Point(184, 62);
+            groupBox_projectMandatoryFields.Name = "groupBox_projectMandatoryFields";
+            groupBox_projectMandatoryFields.Size = new System.Drawing.Size(358, 277);
+            groupBox_projectMandatoryFields.TabIndex = 5;
+            groupBox_projectMandatoryFields.TabStop = false;
+            groupBox_projectMandatoryFields.Text = "Mandatory";
+            // 
+            // checkBox_defaultProjectDepartment
+            // 
+            checkBox_defaultProjectDepartment.AutoSize = true;
+            checkBox_defaultProjectDepartment.Location = new System.Drawing.Point(283, 243);
+            checkBox_defaultProjectDepartment.Name = "checkBox_defaultProjectDepartment";
+            checkBox_defaultProjectDepartment.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultProjectDepartment.TabIndex = 9;
+            checkBox_defaultProjectDepartment.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultProjectDepartment, "Set default values for all rows of a particular column field");
+            checkBox_defaultProjectDepartment.UseVisualStyleBackColor = true;
+            checkBox_defaultProjectDepartment.CheckedChanged += checkBox_defaultProjectDepartment_CheckedChanged;
+            // 
+            // label_projectDepartment
+            // 
+            label_projectDepartment.AutoSize = true;
+            label_projectDepartment.Location = new System.Drawing.Point(6, 244);
+            label_projectDepartment.Name = "label_projectDepartment";
+            label_projectDepartment.Size = new System.Drawing.Size(121, 17);
+            label_projectDepartment.TabIndex = 7;
+            label_projectDepartment.Text = "Department Name";
+            // 
+            // comboBox_projectDepartment
+            // 
+            comboBox_projectDepartment.FormattingEnabled = true;
+            comboBox_projectDepartment.Location = new System.Drawing.Point(138, 241);
+            comboBox_projectDepartment.Name = "comboBox_projectDepartment";
+            comboBox_projectDepartment.Size = new System.Drawing.Size(139, 25);
+            comboBox_projectDepartment.TabIndex = 8;
+            // 
+            // checkBox_defaultLegalEntity
+            // 
+            checkBox_defaultLegalEntity.AutoSize = true;
+            checkBox_defaultLegalEntity.Location = new System.Drawing.Point(283, 181);
+            checkBox_defaultLegalEntity.Name = "checkBox_defaultLegalEntity";
+            checkBox_defaultLegalEntity.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultLegalEntity.TabIndex = 6;
+            checkBox_defaultLegalEntity.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultLegalEntity, "Set default values for all rows of a particular column field");
+            checkBox_defaultLegalEntity.UseVisualStyleBackColor = true;
+            checkBox_defaultLegalEntity.CheckedChanged += checkBox_defaultLegalEntity_CheckedChanged;
+            // 
+            // checkBox_defaultProjectTemplate
+            // 
+            checkBox_defaultProjectTemplate.AutoSize = true;
+            checkBox_defaultProjectTemplate.Location = new System.Drawing.Point(283, 88);
+            checkBox_defaultProjectTemplate.Name = "checkBox_defaultProjectTemplate";
+            checkBox_defaultProjectTemplate.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultProjectTemplate.TabIndex = 5;
+            checkBox_defaultProjectTemplate.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultProjectTemplate, "Set default values for all rows of a particular column field");
+            checkBox_defaultProjectTemplate.UseVisualStyleBackColor = true;
+            checkBox_defaultProjectTemplate.CheckedChanged += checkBox_defaultProjectTemplate_CheckedChanged;
+            // 
+            // checkBox_defaultProjectType
+            // 
+            checkBox_defaultProjectType.AutoSize = true;
+            checkBox_defaultProjectType.Location = new System.Drawing.Point(283, 212);
+            checkBox_defaultProjectType.Name = "checkBox_defaultProjectType";
+            checkBox_defaultProjectType.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultProjectType.TabIndex = 4;
+            checkBox_defaultProjectType.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultProjectType, "Set default values for all rows of a particular column field");
+            checkBox_defaultProjectType.UseVisualStyleBackColor = true;
+            checkBox_defaultProjectType.CheckedChanged += checkBox_defaultProjectType_CheckedChanged;
+            // 
+            // checkBox_defaultCurrencyISO
+            // 
+            checkBox_defaultCurrencyISO.AutoSize = true;
+            checkBox_defaultCurrencyISO.Location = new System.Drawing.Point(283, 150);
+            checkBox_defaultCurrencyISO.Name = "checkBox_defaultCurrencyISO";
+            checkBox_defaultCurrencyISO.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultCurrencyISO.TabIndex = 4;
+            checkBox_defaultCurrencyISO.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultCurrencyISO, "Set default values for all rows of a particular column field");
+            checkBox_defaultCurrencyISO.UseVisualStyleBackColor = true;
+            checkBox_defaultCurrencyISO.CheckedChanged += checkBox_defaultCurrencyISO_CheckedChanged;
+            // 
+            // label_projectLegalEntity
+            // 
+            label_projectLegalEntity.AutoSize = true;
+            label_projectLegalEntity.Location = new System.Drawing.Point(6, 182);
+            label_projectLegalEntity.Name = "label_projectLegalEntity";
+            label_projectLegalEntity.Size = new System.Drawing.Size(78, 17);
+            label_projectLegalEntity.TabIndex = 1;
+            label_projectLegalEntity.Text = "Legal Entity";
+            // 
+            // comboBox_projectLegalEntity
+            // 
+            comboBox_projectLegalEntity.FormattingEnabled = true;
+            comboBox_projectLegalEntity.Location = new System.Drawing.Point(138, 179);
+            comboBox_projectLegalEntity.Name = "comboBox_projectLegalEntity";
+            comboBox_projectLegalEntity.Size = new System.Drawing.Size(139, 25);
+            comboBox_projectLegalEntity.TabIndex = 3;
+            // 
+            // label_projectCurrencyISO
+            // 
+            label_projectCurrencyISO.AutoSize = true;
+            label_projectCurrencyISO.Location = new System.Drawing.Point(6, 151);
+            label_projectCurrencyISO.Name = "label_projectCurrencyISO";
+            label_projectCurrencyISO.Size = new System.Drawing.Size(87, 17);
+            label_projectCurrencyISO.TabIndex = 1;
+            label_projectCurrencyISO.Text = "Currency ISO";
+            // 
+            // label_projectType
+            // 
+            label_projectType.AutoSize = true;
+            label_projectType.Location = new System.Drawing.Point(6, 213);
+            label_projectType.Name = "label_projectType";
+            label_projectType.Size = new System.Drawing.Size(82, 17);
+            label_projectType.TabIndex = 1;
+            label_projectType.Text = "Project Type";
+            // 
+            // comboBox_projectCurrencyISO
+            // 
+            comboBox_projectCurrencyISO.FormattingEnabled = true;
+            comboBox_projectCurrencyISO.Location = new System.Drawing.Point(138, 148);
+            comboBox_projectCurrencyISO.Name = "comboBox_projectCurrencyISO";
+            comboBox_projectCurrencyISO.Size = new System.Drawing.Size(139, 25);
+            comboBox_projectCurrencyISO.TabIndex = 3;
+            // 
+            // label_projectManager
+            // 
+            label_projectManager.AutoSize = true;
+            label_projectManager.Location = new System.Drawing.Point(6, 120);
+            label_projectManager.Name = "label_projectManager";
+            label_projectManager.Size = new System.Drawing.Size(79, 17);
+            label_projectManager.TabIndex = 1;
+            label_projectManager.Text = "P. M. Initials";
+            // 
+            // comboBox_projectManager
+            // 
+            comboBox_projectManager.FormattingEnabled = true;
+            comboBox_projectManager.Location = new System.Drawing.Point(138, 117);
+            comboBox_projectManager.Name = "comboBox_projectManager";
+            comboBox_projectManager.Size = new System.Drawing.Size(139, 25);
+            comboBox_projectManager.TabIndex = 3;
+            // 
+            // label_projectTemplate
+            // 
+            label_projectTemplate.AutoSize = true;
+            label_projectTemplate.Location = new System.Drawing.Point(6, 89);
+            label_projectTemplate.Name = "label_projectTemplate";
+            label_projectTemplate.Size = new System.Drawing.Size(109, 17);
+            label_projectTemplate.TabIndex = 1;
+            label_projectTemplate.Text = "Project Template";
+            // 
+            // comboBox_projectType
+            // 
+            comboBox_projectType.FormattingEnabled = true;
+            comboBox_projectType.Location = new System.Drawing.Point(138, 210);
+            comboBox_projectType.Name = "comboBox_projectType";
+            comboBox_projectType.Size = new System.Drawing.Size(139, 25);
+            comboBox_projectType.TabIndex = 3;
+            // 
+            // comboBox_projectTemplate
+            // 
+            comboBox_projectTemplate.FormattingEnabled = true;
+            comboBox_projectTemplate.Location = new System.Drawing.Point(138, 86);
+            comboBox_projectTemplate.Name = "comboBox_projectTemplate";
+            comboBox_projectTemplate.Size = new System.Drawing.Size(139, 25);
+            comboBox_projectTemplate.TabIndex = 3;
+            // 
+            // label_projectCustomerNo
+            // 
+            label_projectCustomerNo.AutoSize = true;
+            label_projectCustomerNo.Location = new System.Drawing.Point(6, 58);
+            label_projectCustomerNo.Name = "label_projectCustomerNo";
+            label_projectCustomerNo.Size = new System.Drawing.Size(89, 17);
+            label_projectCustomerNo.TabIndex = 1;
+            label_projectCustomerNo.Text = "Customer No";
+            // 
+            // comboBox_projectCustomerNo
+            // 
+            comboBox_projectCustomerNo.FormattingEnabled = true;
+            comboBox_projectCustomerNo.Location = new System.Drawing.Point(138, 55);
+            comboBox_projectCustomerNo.Name = "comboBox_projectCustomerNo";
+            comboBox_projectCustomerNo.Size = new System.Drawing.Size(139, 25);
+            comboBox_projectCustomerNo.TabIndex = 3;
+            // 
+            // label_projectName
+            // 
+            label_projectName.AutoSize = true;
+            label_projectName.Location = new System.Drawing.Point(6, 27);
+            label_projectName.Name = "label_projectName";
+            label_projectName.Size = new System.Drawing.Size(90, 17);
+            label_projectName.TabIndex = 1;
+            label_projectName.Text = "Project Name";
+            // 
+            // comboBox_projectName
+            // 
+            comboBox_projectName.FormattingEnabled = true;
+            comboBox_projectName.Location = new System.Drawing.Point(138, 24);
+            comboBox_projectName.Name = "comboBox_projectName";
+            comboBox_projectName.Size = new System.Drawing.Size(139, 25);
+            comboBox_projectName.TabIndex = 3;
+            // 
+            // label_projectSetup
+            // 
+            label_projectSetup.AutoSize = true;
+            label_projectSetup.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold);
+            label_projectSetup.ForeColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            label_projectSetup.Location = new System.Drawing.Point(7, 16);
+            label_projectSetup.Name = "label_projectSetup";
+            label_projectSetup.Size = new System.Drawing.Size(231, 32);
+            label_projectSetup.TabIndex = 0;
+            label_projectSetup.Text = "Project Data Import";
+            // 
+            // button_projectSelectFile
+            // 
+            button_projectSelectFile.BackColor = System.Drawing.Color.FromArgb(226, 43, 141);
+            button_projectSelectFile.Cursor = System.Windows.Forms.Cursors.Hand;
+            button_projectSelectFile.FlatAppearance.BorderSize = 0;
+            button_projectSelectFile.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            button_projectSelectFile.ForeColor = System.Drawing.Color.White;
+            button_projectSelectFile.Location = new System.Drawing.Point(13, 111);
+            button_projectSelectFile.Name = "button_projectSelectFile";
+            button_projectSelectFile.Size = new System.Drawing.Size(80, 29);
+            button_projectSelectFile.TabIndex = 4;
+            button_projectSelectFile.Text = "Select File";
+            defaultToolTip.SetToolTip(button_projectSelectFile, "Select input CSV file");
+            button_projectSelectFile.UseVisualStyleBackColor = false;
+            button_projectSelectFile.Click += button_select_project_file_Click;
+            // 
+            // tmrExpand
+            // 
+            tmrExpand.Interval = 10;
+            tmrExpand.Tick += tmrExpand_Tick;
+            // 
+            // defaultToolTip
+            // 
+            defaultToolTip.ShowAlways = true;
             // 
             // UserControl_ProjectImport
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.panel_projectFieldMapping);
-            this.Controls.Add(this.panel_projectButtons);
-            this.Controls.Add(this.panel_projectMessage);
-            this.Controls.Add(this.panel_projectDataTable);
-            this.Name = "UserControl_ProjectImport";
-            this.Size = new System.Drawing.Size(1006, 642);
-            this.panel_projectDataTable.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridView_project)).EndInit();
-            this.panel_projectMessage.ResumeLayout(false);
-            this.panel_projectMessage.PerformLayout();
-            this.panel_projectButtons.ResumeLayout(false);
-            this.panel_projectFieldMapping.ResumeLayout(false);
-            this.panel_projectFieldMapping.PerformLayout();
-            this.flowLayoutPanel_nonMandatoryFields.ResumeLayout(false);
-            this.panel_NonMandatoryButton.ResumeLayout(false);
-            this.panel_NonMandatoryButton.PerformLayout();
-            this.panel_NonMandatoryFields.ResumeLayout(false);
-            this.panel_NonMandatoryFields.PerformLayout();
-            this.groupBox_projectMandatoryFields.ResumeLayout(false);
-            this.groupBox_projectMandatoryFields.PerformLayout();
-            this.ResumeLayout(false);
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(panel_projectFieldMapping);
+            Controls.Add(panel_projectButtons);
+            Controls.Add(panel_projectMessage);
+            Controls.Add(panel_projectDataTable);
+            Name = "UserControl_ProjectImport";
+            Size = new System.Drawing.Size(1006, 642);
+            panel_projectDataTable.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)dataGridView_project).EndInit();
+            panel_projectMessage.ResumeLayout(false);
+            panel_projectMessage.PerformLayout();
+            panel_projectButtons.ResumeLayout(false);
+            panel_projectFieldMapping.ResumeLayout(false);
+            panel_projectFieldMapping.PerformLayout();
+            flowLayoutPanel_nonMandatoryFields.ResumeLayout(false);
+            panel_NonMandatoryButton.ResumeLayout(false);
+            panel_NonMandatoryButton.PerformLayout();
+            panel_NonMandatoryFields.ResumeLayout(false);
+            panel_NonMandatoryFields.PerformLayout();
+            groupBox_projectMandatoryFields.ResumeLayout(false);
+            groupBox_projectMandatoryFields.PerformLayout();
+            ResumeLayout(false);
 
         }
 

--- a/UserControls/UserControl_ProjectImport.resx
+++ b/UserControls/UserControl_ProjectImport.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -65,8 +125,5 @@
   </metadata>
   <metadata name="tmrExpand.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>149, 17</value>
-  </metadata>
-  <metadata name="defaultToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>259, 17</value>
   </metadata>
 </root>

--- a/UserControls/UserControl_RecurringPaymentPlanUpdate.Designer.cs
+++ b/UserControls/UserControl_RecurringPaymentPlanUpdate.Designer.cs
@@ -287,6 +287,7 @@
             // 
             // comboBox_delimiter
             // 
+            comboBox_delimiter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             comboBox_delimiter.FormattingEnabled = true;
             comboBox_delimiter.Location = new System.Drawing.Point(82, 72);
             comboBox_delimiter.Name = "comboBox_delimiter";

--- a/UserControls/UserControl_TaskImport.Designer.cs
+++ b/UserControls/UserControl_TaskImport.Designer.cs
@@ -28,943 +28,876 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            this.WorkerFetcher = new System.ComponentModel.BackgroundWorker();
-            this.panel_taskDataTable = new System.Windows.Forms.Panel();
-            this.dataGridView_task = new System.Windows.Forms.DataGridView();
-            this.panel_projectMessage = new System.Windows.Forms.Panel();
-            this.textBox_taskImportMessages = new System.Windows.Forms.TextBox();
-            this.panel_taskButtons = new System.Windows.Forms.Panel();
-            this.button_clear = new System.Windows.Forms.Button();
-            this.button_import = new System.Windows.Forms.Button();
-            this.button_validate = new System.Windows.Forms.Button();
-            this.button_stop = new System.Windows.Forms.Button();
-            this.panel_taskFieldMapping = new System.Windows.Forms.Panel();
-            this.flowLayoutPanel_nonMandatoryFields = new System.Windows.Forms.FlowLayoutPanel();
-            this.panel_NonMandatoryButton = new System.Windows.Forms.Panel();
-            this.label_nonMandatoryFields = new System.Windows.Forms.Label();
-            this.button_expandNonMandatory = new System.Windows.Forms.Button();
-            this.panel_NonMandatoryFields = new System.Windows.Forms.Panel();
-            this.panel1 = new System.Windows.Forms.Panel();
-            this.label_taskTDRProperties = new System.Windows.Forms.Label();
-            this.label_paymentInvoiceDate = new System.Windows.Forms.Label();
-            this.label_paymentName = new System.Windows.Forms.Label();
-            this.checkBox_defaultAdditionalTextIsRequired = new System.Windows.Forms.CheckBox();
-            this.label_paymentProductNo = new System.Windows.Forms.Label();
-            this.comboBox_paymentInvoiceDate = new System.Windows.Forms.ComboBox();
-            this.comboBox_paymentName = new System.Windows.Forms.ComboBox();
-            this.comboBox_paymentProductNo = new System.Windows.Forms.ComboBox();
-            this.comboBox_taskHourlyRate = new System.Windows.Forms.ComboBox();
-            this.label_taskHourlyRate = new System.Windows.Forms.Label();
-            this.checkBox_defaultPaymentRecognitionModel = new System.Windows.Forms.CheckBox();
-            this.checkBox_defaultIsBillable = new System.Windows.Forms.CheckBox();
-            this.label_paymentRecognitionModel = new System.Windows.Forms.Label();
-            this.comboBox_budgetAmount = new System.Windows.Forms.ComboBox();
-            this.comboBox_paymentRecognitionModel = new System.Windows.Forms.ComboBox();
-            this.comboBox_paymentAmount = new System.Windows.Forms.ComboBox();
-            this.label_isBillable = new System.Windows.Forms.Label();
-            this.label_paymentAmount = new System.Windows.Forms.Label();
-            this.label_budgetAmount = new System.Windows.Forms.Label();
-            this.comboBox_isBillable = new System.Windows.Forms.ComboBox();
-            this.label_taskNo = new System.Windows.Forms.Label();
-            this.label_hourlyRate = new System.Windows.Forms.Label();
-            this.comboBox_parentTaskNo = new System.Windows.Forms.ComboBox();
-            this.label_parentTaskNo = new System.Windows.Forms.Label();
-            this.comboBox_taskNo = new System.Windows.Forms.ComboBox();
-            this.label_budgetHours = new System.Windows.Forms.Label();
-            this.comboBox_budgetHours = new System.Windows.Forms.ComboBox();
-            this.checkBox_defaultIsReadyForInvoicing = new System.Windows.Forms.CheckBox();
-            this.label_isReadyForInvoicing = new System.Windows.Forms.Label();
-            this.comboBox_description = new System.Windows.Forms.ComboBox();
-            this.comboBox_isReadyForInvoicing = new System.Windows.Forms.ComboBox();
-            this.label_description = new System.Windows.Forms.Label();
-            this.label_additionalTextIsRequired = new System.Windows.Forms.Label();
-            this.comboBox_additionalTextIsRequired = new System.Windows.Forms.ComboBox();
-            this.comboBox_hourlyRate = new System.Windows.Forms.ComboBox();
-            this.label_delimiter = new System.Windows.Forms.Label();
-            this.comboBox_delimiter = new System.Windows.Forms.ComboBox();
-            this.groupBox_taskMandatoryFields = new System.Windows.Forms.GroupBox();
-            this.checkBox_defaultTaskType = new System.Windows.Forms.CheckBox();
-            this.comboBox_contractName = new System.Windows.Forms.ComboBox();
-            this.label_contractName = new System.Windows.Forms.Label();
-            this.label_projectNo = new System.Windows.Forms.Label();
-            this.comboBox_projectNo = new System.Windows.Forms.ComboBox();
-            this.label_taskType = new System.Windows.Forms.Label();
-            this.comboBox_taskType = new System.Windows.Forms.ComboBox();
-            this.label_endDate = new System.Windows.Forms.Label();
-            this.comboBox_endDate = new System.Windows.Forms.ComboBox();
-            this.label_startDate = new System.Windows.Forms.Label();
-            this.comboBox_startDate = new System.Windows.Forms.ComboBox();
-            this.label_taskName = new System.Windows.Forms.Label();
-            this.comboBox_taskName = new System.Windows.Forms.ComboBox();
-            this.label_taskSetup = new System.Windows.Forms.Label();
-            this.button_taskSelectFile = new System.Windows.Forms.Button();
-            this.tmrExpand = new System.Windows.Forms.Timer(this.components);
-            this.defaultToolTip = new System.Windows.Forms.ToolTip(this.components);
-            this.panel_taskDataTable.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridView_task)).BeginInit();
-            this.panel_projectMessage.SuspendLayout();
-            this.panel_taskButtons.SuspendLayout();
-            this.panel_taskFieldMapping.SuspendLayout();
-            this.flowLayoutPanel_nonMandatoryFields.SuspendLayout();
-            this.panel_NonMandatoryButton.SuspendLayout();
-            this.panel_NonMandatoryFields.SuspendLayout();
-            this.panel1.SuspendLayout();
-            this.groupBox_taskMandatoryFields.SuspendLayout();
-            this.SuspendLayout();
+            components = new System.ComponentModel.Container();
+            WorkerFetcher = new System.ComponentModel.BackgroundWorker();
+            panel_taskDataTable = new System.Windows.Forms.Panel();
+            dataGridView_task = new System.Windows.Forms.DataGridView();
+            panel_projectMessage = new System.Windows.Forms.Panel();
+            textBox_taskImportMessages = new System.Windows.Forms.TextBox();
+            panel_taskButtons = new System.Windows.Forms.Panel();
+            button_clear = new System.Windows.Forms.Button();
+            button_import = new System.Windows.Forms.Button();
+            button_validate = new System.Windows.Forms.Button();
+            button_stop = new System.Windows.Forms.Button();
+            panel_taskFieldMapping = new System.Windows.Forms.Panel();
+            flowLayoutPanel_nonMandatoryFields = new System.Windows.Forms.FlowLayoutPanel();
+            panel_NonMandatoryButton = new System.Windows.Forms.Panel();
+            label_nonMandatoryFields = new System.Windows.Forms.Label();
+            button_expandNonMandatory = new System.Windows.Forms.Button();
+            panel_NonMandatoryFields = new System.Windows.Forms.Panel();
+            panel1 = new System.Windows.Forms.Panel();
+            label_taskTDRProperties = new System.Windows.Forms.Label();
+            label_paymentInvoiceDate = new System.Windows.Forms.Label();
+            label_paymentName = new System.Windows.Forms.Label();
+            checkBox_defaultAdditionalTextIsRequired = new System.Windows.Forms.CheckBox();
+            label_paymentProductNo = new System.Windows.Forms.Label();
+            comboBox_paymentInvoiceDate = new System.Windows.Forms.ComboBox();
+            comboBox_paymentName = new System.Windows.Forms.ComboBox();
+            comboBox_paymentProductNo = new System.Windows.Forms.ComboBox();
+            comboBox_taskHourlyRate = new System.Windows.Forms.ComboBox();
+            label_taskHourlyRate = new System.Windows.Forms.Label();
+            checkBox_defaultPaymentRecognitionModel = new System.Windows.Forms.CheckBox();
+            checkBox_defaultIsBillable = new System.Windows.Forms.CheckBox();
+            label_paymentRecognitionModel = new System.Windows.Forms.Label();
+            comboBox_budgetAmount = new System.Windows.Forms.ComboBox();
+            comboBox_paymentRecognitionModel = new System.Windows.Forms.ComboBox();
+            comboBox_paymentAmount = new System.Windows.Forms.ComboBox();
+            label_isBillable = new System.Windows.Forms.Label();
+            label_paymentAmount = new System.Windows.Forms.Label();
+            label_budgetAmount = new System.Windows.Forms.Label();
+            comboBox_isBillable = new System.Windows.Forms.ComboBox();
+            label_taskNo = new System.Windows.Forms.Label();
+            label_hourlyRate = new System.Windows.Forms.Label();
+            comboBox_parentTaskNo = new System.Windows.Forms.ComboBox();
+            label_parentTaskNo = new System.Windows.Forms.Label();
+            comboBox_taskNo = new System.Windows.Forms.ComboBox();
+            label_budgetHours = new System.Windows.Forms.Label();
+            comboBox_budgetHours = new System.Windows.Forms.ComboBox();
+            checkBox_defaultIsReadyForInvoicing = new System.Windows.Forms.CheckBox();
+            label_isReadyForInvoicing = new System.Windows.Forms.Label();
+            comboBox_description = new System.Windows.Forms.ComboBox();
+            comboBox_isReadyForInvoicing = new System.Windows.Forms.ComboBox();
+            label_description = new System.Windows.Forms.Label();
+            label_additionalTextIsRequired = new System.Windows.Forms.Label();
+            comboBox_additionalTextIsRequired = new System.Windows.Forms.ComboBox();
+            comboBox_hourlyRate = new System.Windows.Forms.ComboBox();
+            label_delimiter = new System.Windows.Forms.Label();
+            comboBox_delimiter = new System.Windows.Forms.ComboBox();
+            groupBox_taskMandatoryFields = new System.Windows.Forms.GroupBox();
+            checkBox_defaultTaskType = new System.Windows.Forms.CheckBox();
+            comboBox_contractName = new System.Windows.Forms.ComboBox();
+            label_contractName = new System.Windows.Forms.Label();
+            label_projectNo = new System.Windows.Forms.Label();
+            comboBox_projectNo = new System.Windows.Forms.ComboBox();
+            label_taskType = new System.Windows.Forms.Label();
+            comboBox_taskType = new System.Windows.Forms.ComboBox();
+            label_endDate = new System.Windows.Forms.Label();
+            comboBox_endDate = new System.Windows.Forms.ComboBox();
+            label_startDate = new System.Windows.Forms.Label();
+            comboBox_startDate = new System.Windows.Forms.ComboBox();
+            label_taskName = new System.Windows.Forms.Label();
+            comboBox_taskName = new System.Windows.Forms.ComboBox();
+            label_taskSetup = new System.Windows.Forms.Label();
+            button_taskSelectFile = new System.Windows.Forms.Button();
+            tmrExpand = new System.Windows.Forms.Timer(components);
+            defaultToolTip = new System.Windows.Forms.ToolTip(components);
+            panel_taskDataTable.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)dataGridView_task).BeginInit();
+            panel_projectMessage.SuspendLayout();
+            panel_taskButtons.SuspendLayout();
+            panel_taskFieldMapping.SuspendLayout();
+            flowLayoutPanel_nonMandatoryFields.SuspendLayout();
+            panel_NonMandatoryButton.SuspendLayout();
+            panel_NonMandatoryFields.SuspendLayout();
+            panel1.SuspendLayout();
+            groupBox_taskMandatoryFields.SuspendLayout();
+            SuspendLayout();
             // 
             // WorkerFetcher
             // 
-            this.WorkerFetcher.WorkerReportsProgress = true;
-            this.WorkerFetcher.WorkerSupportsCancellation = true;
-            this.WorkerFetcher.DoWork += new System.ComponentModel.DoWorkEventHandler(this.WorkerFetcherDoWork);
+            WorkerFetcher.WorkerReportsProgress = true;
+            WorkerFetcher.WorkerSupportsCancellation = true;
+            WorkerFetcher.DoWork += WorkerFetcherDoWork;
             // 
             // panel_taskDataTable
             // 
-            this.panel_taskDataTable.Controls.Add(this.dataGridView_task);
-            this.panel_taskDataTable.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel_taskDataTable.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.panel_taskDataTable.Location = new System.Drawing.Point(0, 770);
-            this.panel_taskDataTable.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_taskDataTable.Name = "panel_taskDataTable";
-            this.panel_taskDataTable.Size = new System.Drawing.Size(1437, 300);
-            this.panel_taskDataTable.TabIndex = 6;
+            panel_taskDataTable.Controls.Add(dataGridView_task);
+            panel_taskDataTable.Dock = System.Windows.Forms.DockStyle.Bottom;
+            panel_taskDataTable.ForeColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            panel_taskDataTable.Location = new System.Drawing.Point(0, 462);
+            panel_taskDataTable.Name = "panel_taskDataTable";
+            panel_taskDataTable.Size = new System.Drawing.Size(1006, 180);
+            panel_taskDataTable.TabIndex = 6;
             // 
             // dataGridView_task
             // 
-            this.dataGridView_task.BackgroundColor = System.Drawing.Color.DarkGray;
-            this.dataGridView_task.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.dataGridView_task.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dataGridView_task.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.dataGridView_task.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.dataGridView_task.Location = new System.Drawing.Point(0, 0);
-            this.dataGridView_task.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.dataGridView_task.Name = "dataGridView_task";
-            this.dataGridView_task.RowHeadersWidth = 62;
-            this.dataGridView_task.Size = new System.Drawing.Size(1437, 300);
-            this.dataGridView_task.TabIndex = 0;
+            dataGridView_task.BackgroundColor = System.Drawing.Color.DarkGray;
+            dataGridView_task.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            dataGridView_task.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            dataGridView_task.Dock = System.Windows.Forms.DockStyle.Bottom;
+            dataGridView_task.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold);
+            dataGridView_task.Location = new System.Drawing.Point(0, 0);
+            dataGridView_task.Name = "dataGridView_task";
+            dataGridView_task.RowHeadersWidth = 62;
+            dataGridView_task.Size = new System.Drawing.Size(1006, 180);
+            dataGridView_task.TabIndex = 0;
             // 
             // panel_projectMessage
             // 
-            this.panel_projectMessage.Controls.Add(this.textBox_taskImportMessages);
-            this.panel_projectMessage.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel_projectMessage.Location = new System.Drawing.Point(0, 463);
-            this.panel_projectMessage.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_projectMessage.Name = "panel_projectMessage";
-            this.panel_projectMessage.Size = new System.Drawing.Size(1437, 307);
-            this.panel_projectMessage.TabIndex = 10;
+            panel_projectMessage.Controls.Add(textBox_taskImportMessages);
+            panel_projectMessage.Dock = System.Windows.Forms.DockStyle.Bottom;
+            panel_projectMessage.Location = new System.Drawing.Point(0, 278);
+            panel_projectMessage.Name = "panel_projectMessage";
+            panel_projectMessage.Size = new System.Drawing.Size(1006, 184);
+            panel_projectMessage.TabIndex = 10;
             // 
             // textBox_taskImportMessages
             // 
-            this.textBox_taskImportMessages.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
-            this.textBox_taskImportMessages.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.textBox_taskImportMessages.Cursor = System.Windows.Forms.Cursors.Default;
-            this.textBox_taskImportMessages.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.textBox_taskImportMessages.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.textBox_taskImportMessages.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.textBox_taskImportMessages.Location = new System.Drawing.Point(0, 0);
-            this.textBox_taskImportMessages.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.textBox_taskImportMessages.Multiline = true;
-            this.textBox_taskImportMessages.Name = "textBox_taskImportMessages";
-            this.textBox_taskImportMessages.ReadOnly = true;
-            this.textBox_taskImportMessages.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.textBox_taskImportMessages.Size = new System.Drawing.Size(1437, 307);
-            this.textBox_taskImportMessages.TabIndex = 0;
-            this.textBox_taskImportMessages.WordWrap = false;
-            this.defaultToolTip.SetToolTip(this.textBox_taskImportMessages, "Validation or import status");
-            this.textBox_taskImportMessages.MouseClick += new System.Windows.Forms.MouseEventHandler(this.textBox_taskImportMessages_MouseClick);
+            textBox_taskImportMessages.BackColor = System.Drawing.Color.FromArgb(224, 224, 224);
+            textBox_taskImportMessages.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            textBox_taskImportMessages.Dock = System.Windows.Forms.DockStyle.Bottom;
+            textBox_taskImportMessages.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold);
+            textBox_taskImportMessages.ForeColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            textBox_taskImportMessages.Location = new System.Drawing.Point(0, 0);
+            textBox_taskImportMessages.Multiline = true;
+            textBox_taskImportMessages.Name = "textBox_taskImportMessages";
+            textBox_taskImportMessages.ReadOnly = true;
+            textBox_taskImportMessages.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            textBox_taskImportMessages.Size = new System.Drawing.Size(1006, 184);
+            textBox_taskImportMessages.TabIndex = 0;
+            defaultToolTip.SetToolTip(textBox_taskImportMessages, "Validation or import status");
+            textBox_taskImportMessages.WordWrap = false;
+            textBox_taskImportMessages.MouseClick += textBox_taskImportMessages_MouseClick;
             // 
             // panel_taskButtons
             // 
-            this.panel_taskButtons.Controls.Add(this.button_clear);
-            this.panel_taskButtons.Controls.Add(this.button_import);
-            this.panel_taskButtons.Controls.Add(this.button_validate);
-            this.panel_taskButtons.Controls.Add(this.button_stop);
-            this.panel_taskButtons.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel_taskButtons.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.panel_taskButtons.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.panel_taskButtons.Location = new System.Drawing.Point(0, 376);
-            this.panel_taskButtons.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_taskButtons.Name = "panel_taskButtons";
-            this.panel_taskButtons.Size = new System.Drawing.Size(1437, 87);
-            this.panel_taskButtons.TabIndex = 12;
+            panel_taskButtons.Controls.Add(button_clear);
+            panel_taskButtons.Controls.Add(button_import);
+            panel_taskButtons.Controls.Add(button_validate);
+            panel_taskButtons.Controls.Add(button_stop);
+            panel_taskButtons.Dock = System.Windows.Forms.DockStyle.Bottom;
+            panel_taskButtons.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold);
+            panel_taskButtons.ForeColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            panel_taskButtons.Location = new System.Drawing.Point(0, 226);
+            panel_taskButtons.Name = "panel_taskButtons";
+            panel_taskButtons.Size = new System.Drawing.Size(1006, 52);
+            panel_taskButtons.TabIndex = 12;
             // 
             // button_clear
             // 
-            this.button_clear.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.button_clear.BackColor = System.Drawing.Color.DimGray;
-            this.button_clear.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_clear.FlatAppearance.BorderSize = 0;
-            this.button_clear.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_clear.ForeColor = System.Drawing.Color.White;
-            this.button_clear.Location = new System.Drawing.Point(20, 20);
-            this.button_clear.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_clear.Name = "button_clear";
-            this.button_clear.Size = new System.Drawing.Size(114, 48);
-            this.button_clear.TabIndex = 12;
-            this.button_clear.Text = "Reset All";
-            this.defaultToolTip.SetToolTip(this.button_clear, "Reset everything and reload data from TLP");
-            this.button_clear.UseVisualStyleBackColor = false;
-            this.button_clear.Click += new System.EventHandler(this.button_clear_Click);
+            button_clear.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            button_clear.BackColor = System.Drawing.Color.DimGray;
+            button_clear.Cursor = System.Windows.Forms.Cursors.Hand;
+            button_clear.FlatAppearance.BorderSize = 0;
+            button_clear.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            button_clear.ForeColor = System.Drawing.Color.White;
+            button_clear.Location = new System.Drawing.Point(14, 12);
+            button_clear.Name = "button_clear";
+            button_clear.Size = new System.Drawing.Size(80, 29);
+            button_clear.TabIndex = 12;
+            button_clear.Text = "Reset All";
+            defaultToolTip.SetToolTip(button_clear, "Reset everything and reload data from TLP");
+            button_clear.UseVisualStyleBackColor = false;
+            button_clear.Click += button_clear_Click;
             // 
             // button_import
             // 
-            this.button_import.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.button_import.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(43)))), ((int)(((byte)(141)))));
-            this.button_import.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_import.FlatAppearance.BorderSize = 0;
-            this.button_import.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_import.ForeColor = System.Drawing.Color.White;
-            this.button_import.Location = new System.Drawing.Point(1310, 20);
-            this.button_import.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_import.Name = "button_import";
-            this.button_import.Size = new System.Drawing.Size(114, 48);
-            this.button_import.TabIndex = 7;
-            this.button_import.Text = "Import";
-            this.defaultToolTip.SetToolTip(this.button_import, "Import all data");
-            this.button_import.UseVisualStyleBackColor = false;
-            this.button_import.Click += new System.EventHandler(this.button_import_Click);
+            button_import.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            button_import.BackColor = System.Drawing.Color.FromArgb(226, 43, 141);
+            button_import.Cursor = System.Windows.Forms.Cursors.Hand;
+            button_import.FlatAppearance.BorderSize = 0;
+            button_import.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            button_import.ForeColor = System.Drawing.Color.White;
+            button_import.Location = new System.Drawing.Point(917, 12);
+            button_import.Name = "button_import";
+            button_import.Size = new System.Drawing.Size(80, 29);
+            button_import.TabIndex = 7;
+            button_import.Text = "Import";
+            defaultToolTip.SetToolTip(button_import, "Import all data");
+            button_import.UseVisualStyleBackColor = false;
+            button_import.Click += button_import_Click;
             // 
             // button_validate
             // 
-            this.button_validate.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.button_validate.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(43)))), ((int)(((byte)(141)))));
-            this.button_validate.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_validate.FlatAppearance.BorderSize = 0;
-            this.button_validate.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_validate.ForeColor = System.Drawing.Color.White;
-            this.button_validate.Location = new System.Drawing.Point(1064, 20);
-            this.button_validate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_validate.Name = "button_validate";
-            this.button_validate.Size = new System.Drawing.Size(114, 48);
-            this.button_validate.TabIndex = 8;
-            this.button_validate.Text = "Validate";
-            this.defaultToolTip.SetToolTip(this.button_validate, "Validate data input before importing data");
-            this.button_validate.UseVisualStyleBackColor = false;
-            this.button_validate.Click += new System.EventHandler(this.button_validate_Click);
+            button_validate.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            button_validate.BackColor = System.Drawing.Color.FromArgb(226, 43, 141);
+            button_validate.Cursor = System.Windows.Forms.Cursors.Hand;
+            button_validate.FlatAppearance.BorderSize = 0;
+            button_validate.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            button_validate.ForeColor = System.Drawing.Color.White;
+            button_validate.Location = new System.Drawing.Point(745, 12);
+            button_validate.Name = "button_validate";
+            button_validate.Size = new System.Drawing.Size(80, 29);
+            button_validate.TabIndex = 8;
+            button_validate.Text = "Validate";
+            defaultToolTip.SetToolTip(button_validate, "Validate data input before importing data");
+            button_validate.UseVisualStyleBackColor = false;
+            button_validate.Click += button_validate_Click;
             // 
             // button_stop
             // 
-            this.button_stop.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.button_stop.BackColor = System.Drawing.Color.DimGray;
-            this.button_stop.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_stop.FlatAppearance.BorderSize = 0;
-            this.button_stop.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_stop.ForeColor = System.Drawing.Color.White;
-            this.button_stop.Location = new System.Drawing.Point(1187, 20);
-            this.button_stop.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_stop.Name = "button_stop";
-            this.button_stop.Size = new System.Drawing.Size(114, 48);
-            this.button_stop.TabIndex = 11;
-            this.button_stop.Text = "Stop";
-            this.defaultToolTip.SetToolTip(this.button_stop, "Stop validation or import");
-            this.button_stop.UseVisualStyleBackColor = false;
-            this.button_stop.Click += new System.EventHandler(this.button_stop_Click);
+            button_stop.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            button_stop.BackColor = System.Drawing.Color.DimGray;
+            button_stop.Cursor = System.Windows.Forms.Cursors.Hand;
+            button_stop.FlatAppearance.BorderSize = 0;
+            button_stop.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            button_stop.ForeColor = System.Drawing.Color.White;
+            button_stop.Location = new System.Drawing.Point(831, 12);
+            button_stop.Name = "button_stop";
+            button_stop.Size = new System.Drawing.Size(80, 29);
+            button_stop.TabIndex = 11;
+            button_stop.Text = "Stop";
+            defaultToolTip.SetToolTip(button_stop, "Stop validation or import");
+            button_stop.UseVisualStyleBackColor = false;
+            button_stop.Click += button_stop_Click;
             // 
             // panel_taskFieldMapping
             // 
-            this.panel_taskFieldMapping.AutoScroll = true;
-            this.panel_taskFieldMapping.Controls.Add(this.flowLayoutPanel_nonMandatoryFields);
-            this.panel_taskFieldMapping.Controls.Add(this.label_delimiter);
-            this.panel_taskFieldMapping.Controls.Add(this.comboBox_delimiter);
-            this.panel_taskFieldMapping.Controls.Add(this.groupBox_taskMandatoryFields);
-            this.panel_taskFieldMapping.Controls.Add(this.label_taskSetup);
-            this.panel_taskFieldMapping.Controls.Add(this.button_taskSelectFile);
-            this.panel_taskFieldMapping.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel_taskFieldMapping.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.panel_taskFieldMapping.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.panel_taskFieldMapping.Location = new System.Drawing.Point(0, 0);
-            this.panel_taskFieldMapping.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_taskFieldMapping.Name = "panel_taskFieldMapping";
-            this.panel_taskFieldMapping.Size = new System.Drawing.Size(1437, 376);
-            this.panel_taskFieldMapping.TabIndex = 13;
+            panel_taskFieldMapping.AutoScroll = true;
+            panel_taskFieldMapping.Controls.Add(flowLayoutPanel_nonMandatoryFields);
+            panel_taskFieldMapping.Controls.Add(label_delimiter);
+            panel_taskFieldMapping.Controls.Add(comboBox_delimiter);
+            panel_taskFieldMapping.Controls.Add(groupBox_taskMandatoryFields);
+            panel_taskFieldMapping.Controls.Add(label_taskSetup);
+            panel_taskFieldMapping.Controls.Add(button_taskSelectFile);
+            panel_taskFieldMapping.Dock = System.Windows.Forms.DockStyle.Fill;
+            panel_taskFieldMapping.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold);
+            panel_taskFieldMapping.ForeColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            panel_taskFieldMapping.Location = new System.Drawing.Point(0, 0);
+            panel_taskFieldMapping.Name = "panel_taskFieldMapping";
+            panel_taskFieldMapping.Size = new System.Drawing.Size(1006, 226);
+            panel_taskFieldMapping.TabIndex = 13;
             // 
             // flowLayoutPanel_nonMandatoryFields
             // 
-            this.flowLayoutPanel_nonMandatoryFields.Controls.Add(this.panel_NonMandatoryButton);
-            this.flowLayoutPanel_nonMandatoryFields.Controls.Add(this.panel_NonMandatoryFields);
-            this.flowLayoutPanel_nonMandatoryFields.Location = new System.Drawing.Point(751, 100);
-            this.flowLayoutPanel_nonMandatoryFields.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.flowLayoutPanel_nonMandatoryFields.Name = "flowLayoutPanel_nonMandatoryFields";
-            this.flowLayoutPanel_nonMandatoryFields.Size = new System.Drawing.Size(639, 951);
-            this.flowLayoutPanel_nonMandatoryFields.TabIndex = 7;
+            flowLayoutPanel_nonMandatoryFields.Controls.Add(panel_NonMandatoryButton);
+            flowLayoutPanel_nonMandatoryFields.Controls.Add(panel_NonMandatoryFields);
+            flowLayoutPanel_nonMandatoryFields.Location = new System.Drawing.Point(526, 60);
+            flowLayoutPanel_nonMandatoryFields.Name = "flowLayoutPanel_nonMandatoryFields";
+            flowLayoutPanel_nonMandatoryFields.Size = new System.Drawing.Size(447, 571);
+            flowLayoutPanel_nonMandatoryFields.TabIndex = 7;
             // 
             // panel_NonMandatoryButton
             // 
-            this.panel_NonMandatoryButton.Controls.Add(this.label_nonMandatoryFields);
-            this.panel_NonMandatoryButton.Controls.Add(this.button_expandNonMandatory);
-            this.panel_NonMandatoryButton.Location = new System.Drawing.Point(4, 5);
-            this.panel_NonMandatoryButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_NonMandatoryButton.Name = "panel_NonMandatoryButton";
-            this.panel_NonMandatoryButton.Size = new System.Drawing.Size(629, 53);
-            this.panel_NonMandatoryButton.TabIndex = 0;
+            panel_NonMandatoryButton.Controls.Add(label_nonMandatoryFields);
+            panel_NonMandatoryButton.Controls.Add(button_expandNonMandatory);
+            panel_NonMandatoryButton.Location = new System.Drawing.Point(3, 3);
+            panel_NonMandatoryButton.Name = "panel_NonMandatoryButton";
+            panel_NonMandatoryButton.Size = new System.Drawing.Size(440, 32);
+            panel_NonMandatoryButton.TabIndex = 0;
             // 
             // label_nonMandatoryFields
             // 
-            this.label_nonMandatoryFields.AutoSize = true;
-            this.label_nonMandatoryFields.ForeColor = System.Drawing.Color.Black;
-            this.label_nonMandatoryFields.Location = new System.Drawing.Point(66, 13);
-            this.label_nonMandatoryFields.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_nonMandatoryFields.Name = "label_nonMandatoryFields";
-            this.label_nonMandatoryFields.Size = new System.Drawing.Size(107, 17);
-            this.label_nonMandatoryFields.TabIndex = 1;
-            this.label_nonMandatoryFields.Text = "Non-Mandatory";
+            label_nonMandatoryFields.AutoSize = true;
+            label_nonMandatoryFields.ForeColor = System.Drawing.Color.Black;
+            label_nonMandatoryFields.Location = new System.Drawing.Point(46, 8);
+            label_nonMandatoryFields.Name = "label_nonMandatoryFields";
+            label_nonMandatoryFields.Size = new System.Drawing.Size(107, 17);
+            label_nonMandatoryFields.TabIndex = 1;
+            label_nonMandatoryFields.Text = "Non-Mandatory";
             // 
             // button_expandNonMandatory
             // 
-            this.button_expandNonMandatory.BackColor = System.Drawing.Color.White;
-            this.button_expandNonMandatory.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button_expandNonMandatory.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_expandNonMandatory.FlatAppearance.BorderSize = 0;
-            this.button_expandNonMandatory.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_expandNonMandatory.ForeColor = System.Drawing.Color.White;
-            this.button_expandNonMandatory.Location = new System.Drawing.Point(14, 2);
-            this.button_expandNonMandatory.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_expandNonMandatory.Name = "button_expandNonMandatory";
-            this.button_expandNonMandatory.Size = new System.Drawing.Size(43, 50);
-            this.button_expandNonMandatory.TabIndex = 0;
-            this.button_expandNonMandatory.UseVisualStyleBackColor = false;
-            this.button_expandNonMandatory.Click += new System.EventHandler(this.button_expand_Click);
+            button_expandNonMandatory.BackColor = System.Drawing.Color.White;
+            button_expandNonMandatory.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            button_expandNonMandatory.Cursor = System.Windows.Forms.Cursors.Hand;
+            button_expandNonMandatory.FlatAppearance.BorderSize = 0;
+            button_expandNonMandatory.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            button_expandNonMandatory.ForeColor = System.Drawing.Color.White;
+            button_expandNonMandatory.Location = new System.Drawing.Point(10, 1);
+            button_expandNonMandatory.Name = "button_expandNonMandatory";
+            button_expandNonMandatory.Size = new System.Drawing.Size(30, 30);
+            button_expandNonMandatory.TabIndex = 0;
+            button_expandNonMandatory.UseVisualStyleBackColor = false;
+            button_expandNonMandatory.Click += button_expand_Click;
             // 
             // panel_NonMandatoryFields
             // 
-            this.panel_NonMandatoryFields.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
-            this.panel_NonMandatoryFields.Controls.Add(this.panel1);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_paymentInvoiceDate);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_paymentName);
-            this.panel_NonMandatoryFields.Controls.Add(this.checkBox_defaultAdditionalTextIsRequired);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_paymentProductNo);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_paymentInvoiceDate);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_paymentName);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_paymentProductNo);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_taskHourlyRate);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_taskHourlyRate);
-            this.panel_NonMandatoryFields.Controls.Add(this.checkBox_defaultPaymentRecognitionModel);
-            this.panel_NonMandatoryFields.Controls.Add(this.checkBox_defaultIsBillable);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_paymentRecognitionModel);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_budgetAmount);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_paymentRecognitionModel);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_paymentAmount);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_isBillable);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_paymentAmount);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_budgetAmount);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_isBillable);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_taskNo);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_hourlyRate);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_parentTaskNo);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_parentTaskNo);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_taskNo);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_budgetHours);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_budgetHours);
-            this.panel_NonMandatoryFields.Controls.Add(this.checkBox_defaultIsReadyForInvoicing);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_isReadyForInvoicing);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_description);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_isReadyForInvoicing);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_description);
-            this.panel_NonMandatoryFields.Controls.Add(this.label_additionalTextIsRequired);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_additionalTextIsRequired);
-            this.panel_NonMandatoryFields.Controls.Add(this.comboBox_hourlyRate);
-            this.panel_NonMandatoryFields.Location = new System.Drawing.Point(4, 68);
-            this.panel_NonMandatoryFields.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panel_NonMandatoryFields.MaximumSize = new System.Drawing.Size(629, 950);
-            this.panel_NonMandatoryFields.MinimumSize = new System.Drawing.Size(546, 0);
-            this.panel_NonMandatoryFields.Name = "panel_NonMandatoryFields";
-            this.panel_NonMandatoryFields.Size = new System.Drawing.Size(629, 883);
-            this.panel_NonMandatoryFields.TabIndex = 1;
+            panel_NonMandatoryFields.BackColor = System.Drawing.Color.FromArgb(224, 224, 224);
+            panel_NonMandatoryFields.Controls.Add(panel1);
+            panel_NonMandatoryFields.Controls.Add(label_paymentInvoiceDate);
+            panel_NonMandatoryFields.Controls.Add(label_paymentName);
+            panel_NonMandatoryFields.Controls.Add(checkBox_defaultAdditionalTextIsRequired);
+            panel_NonMandatoryFields.Controls.Add(label_paymentProductNo);
+            panel_NonMandatoryFields.Controls.Add(comboBox_paymentInvoiceDate);
+            panel_NonMandatoryFields.Controls.Add(comboBox_paymentName);
+            panel_NonMandatoryFields.Controls.Add(comboBox_paymentProductNo);
+            panel_NonMandatoryFields.Controls.Add(comboBox_taskHourlyRate);
+            panel_NonMandatoryFields.Controls.Add(label_taskHourlyRate);
+            panel_NonMandatoryFields.Controls.Add(checkBox_defaultPaymentRecognitionModel);
+            panel_NonMandatoryFields.Controls.Add(checkBox_defaultIsBillable);
+            panel_NonMandatoryFields.Controls.Add(label_paymentRecognitionModel);
+            panel_NonMandatoryFields.Controls.Add(comboBox_budgetAmount);
+            panel_NonMandatoryFields.Controls.Add(comboBox_paymentRecognitionModel);
+            panel_NonMandatoryFields.Controls.Add(comboBox_paymentAmount);
+            panel_NonMandatoryFields.Controls.Add(label_isBillable);
+            panel_NonMandatoryFields.Controls.Add(label_paymentAmount);
+            panel_NonMandatoryFields.Controls.Add(label_budgetAmount);
+            panel_NonMandatoryFields.Controls.Add(comboBox_isBillable);
+            panel_NonMandatoryFields.Controls.Add(label_taskNo);
+            panel_NonMandatoryFields.Controls.Add(label_hourlyRate);
+            panel_NonMandatoryFields.Controls.Add(comboBox_parentTaskNo);
+            panel_NonMandatoryFields.Controls.Add(label_parentTaskNo);
+            panel_NonMandatoryFields.Controls.Add(comboBox_taskNo);
+            panel_NonMandatoryFields.Controls.Add(label_budgetHours);
+            panel_NonMandatoryFields.Controls.Add(comboBox_budgetHours);
+            panel_NonMandatoryFields.Controls.Add(checkBox_defaultIsReadyForInvoicing);
+            panel_NonMandatoryFields.Controls.Add(label_isReadyForInvoicing);
+            panel_NonMandatoryFields.Controls.Add(comboBox_description);
+            panel_NonMandatoryFields.Controls.Add(comboBox_isReadyForInvoicing);
+            panel_NonMandatoryFields.Controls.Add(label_description);
+            panel_NonMandatoryFields.Controls.Add(label_additionalTextIsRequired);
+            panel_NonMandatoryFields.Controls.Add(comboBox_additionalTextIsRequired);
+            panel_NonMandatoryFields.Controls.Add(comboBox_hourlyRate);
+            panel_NonMandatoryFields.Location = new System.Drawing.Point(3, 41);
+            panel_NonMandatoryFields.MaximumSize = new System.Drawing.Size(440, 570);
+            panel_NonMandatoryFields.MinimumSize = new System.Drawing.Size(382, 0);
+            panel_NonMandatoryFields.Name = "panel_NonMandatoryFields";
+            panel_NonMandatoryFields.Size = new System.Drawing.Size(440, 530);
+            panel_NonMandatoryFields.TabIndex = 1;
             // 
             // panel1
             // 
-            this.panel1.Controls.Add(this.label_taskTDRProperties);
-            this.panel1.Location = new System.Drawing.Point(0, 517);
-            this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(629, 47);
-            this.panel1.TabIndex = 19;
+            panel1.Controls.Add(label_taskTDRProperties);
+            panel1.Location = new System.Drawing.Point(0, 310);
+            panel1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            panel1.Name = "panel1";
+            panel1.Size = new System.Drawing.Size(440, 28);
+            panel1.TabIndex = 19;
             // 
             // label_taskTDRProperties
             // 
-            this.label_taskTDRProperties.AutoSize = true;
-            this.label_taskTDRProperties.Location = new System.Drawing.Point(14, 9);
-            this.label_taskTDRProperties.Name = "label_taskTDRProperties";
-            this.label_taskTDRProperties.Size = new System.Drawing.Size(154, 17);
-            this.label_taskTDRProperties.TabIndex = 0;
-            this.label_taskTDRProperties.Text = "Properties for TDR tasks";
+            label_taskTDRProperties.AutoSize = true;
+            label_taskTDRProperties.Location = new System.Drawing.Point(10, 5);
+            label_taskTDRProperties.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            label_taskTDRProperties.Name = "label_taskTDRProperties";
+            label_taskTDRProperties.Size = new System.Drawing.Size(154, 17);
+            label_taskTDRProperties.TabIndex = 0;
+            label_taskTDRProperties.Text = "Properties for TDR tasks";
             // 
             // label_paymentInvoiceDate
             // 
-            this.label_paymentInvoiceDate.AutoSize = true;
-            this.label_paymentInvoiceDate.Location = new System.Drawing.Point(14, 827);
-            this.label_paymentInvoiceDate.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_paymentInvoiceDate.Name = "label_paymentInvoiceDate";
-            this.label_paymentInvoiceDate.Size = new System.Drawing.Size(141, 17);
-            this.label_paymentInvoiceDate.TabIndex = 1;
-            this.label_paymentInvoiceDate.Text = "Payment Invoice Date";
+            label_paymentInvoiceDate.AutoSize = true;
+            label_paymentInvoiceDate.Location = new System.Drawing.Point(10, 496);
+            label_paymentInvoiceDate.Name = "label_paymentInvoiceDate";
+            label_paymentInvoiceDate.Size = new System.Drawing.Size(141, 17);
+            label_paymentInvoiceDate.TabIndex = 1;
+            label_paymentInvoiceDate.Text = "Payment Invoice Date";
             // 
             // label_paymentName
             // 
-            this.label_paymentName.AutoSize = true;
-            this.label_paymentName.Location = new System.Drawing.Point(14, 775);
-            this.label_paymentName.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_paymentName.Name = "label_paymentName";
-            this.label_paymentName.Size = new System.Drawing.Size(102, 17);
-            this.label_paymentName.TabIndex = 1;
-            this.label_paymentName.Text = "Payment Name";
+            label_paymentName.AutoSize = true;
+            label_paymentName.Location = new System.Drawing.Point(10, 465);
+            label_paymentName.Name = "label_paymentName";
+            label_paymentName.Size = new System.Drawing.Size(102, 17);
+            label_paymentName.TabIndex = 1;
+            label_paymentName.Text = "Payment Name";
             // 
             // checkBox_defaultAdditionalTextIsRequired
             // 
-            this.checkBox_defaultAdditionalTextIsRequired.AutoSize = true;
-            this.checkBox_defaultAdditionalTextIsRequired.Location = new System.Drawing.Point(517, 118);
-            this.checkBox_defaultAdditionalTextIsRequired.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultAdditionalTextIsRequired.Name = "checkBox_defaultAdditionalTextIsRequired";
-            this.checkBox_defaultAdditionalTextIsRequired.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultAdditionalTextIsRequired.TabIndex = 4;
-            this.checkBox_defaultAdditionalTextIsRequired.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultAdditionalTextIsRequired, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultAdditionalTextIsRequired.UseVisualStyleBackColor = true;
-            this.checkBox_defaultAdditionalTextIsRequired.CheckedChanged += new System.EventHandler(this.checkBox_defaultAdditionalTextIsRequired_CheckedChanged);
+            checkBox_defaultAdditionalTextIsRequired.AutoSize = true;
+            checkBox_defaultAdditionalTextIsRequired.Location = new System.Drawing.Point(362, 71);
+            checkBox_defaultAdditionalTextIsRequired.Name = "checkBox_defaultAdditionalTextIsRequired";
+            checkBox_defaultAdditionalTextIsRequired.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultAdditionalTextIsRequired.TabIndex = 4;
+            checkBox_defaultAdditionalTextIsRequired.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultAdditionalTextIsRequired, "Set default values for all rows of a particular column field");
+            checkBox_defaultAdditionalTextIsRequired.UseVisualStyleBackColor = true;
+            checkBox_defaultAdditionalTextIsRequired.CheckedChanged += checkBox_defaultAdditionalTextIsRequired_CheckedChanged;
             // 
             // label_paymentProductNo
             // 
-            this.label_paymentProductNo.AutoSize = true;
-            this.label_paymentProductNo.Location = new System.Drawing.Point(14, 724);
-            this.label_paymentProductNo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_paymentProductNo.Name = "label_paymentProductNo";
-            this.label_paymentProductNo.Size = new System.Drawing.Size(136, 17);
-            this.label_paymentProductNo.TabIndex = 1;
-            this.label_paymentProductNo.Text = "Payment Product No";
+            label_paymentProductNo.AutoSize = true;
+            label_paymentProductNo.Location = new System.Drawing.Point(10, 434);
+            label_paymentProductNo.Name = "label_paymentProductNo";
+            label_paymentProductNo.Size = new System.Drawing.Size(136, 17);
+            label_paymentProductNo.TabIndex = 1;
+            label_paymentProductNo.Text = "Payment Product No";
             // 
             // comboBox_paymentInvoiceDate
             // 
-            this.comboBox_paymentInvoiceDate.FormattingEnabled = true;
-            this.comboBox_paymentInvoiceDate.Location = new System.Drawing.Point(280, 822);
-            this.comboBox_paymentInvoiceDate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_paymentInvoiceDate.Name = "comboBox_paymentInvoiceDate";
-            this.comboBox_paymentInvoiceDate.Size = new System.Drawing.Size(227, 25);
-            this.comboBox_paymentInvoiceDate.TabIndex = 18;
+            comboBox_paymentInvoiceDate.FormattingEnabled = true;
+            comboBox_paymentInvoiceDate.Location = new System.Drawing.Point(196, 493);
+            comboBox_paymentInvoiceDate.Name = "comboBox_paymentInvoiceDate";
+            comboBox_paymentInvoiceDate.Size = new System.Drawing.Size(160, 25);
+            comboBox_paymentInvoiceDate.TabIndex = 18;
             // 
             // comboBox_paymentName
             // 
-            this.comboBox_paymentName.FormattingEnabled = true;
-            this.comboBox_paymentName.Location = new System.Drawing.Point(280, 770);
-            this.comboBox_paymentName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_paymentName.Name = "comboBox_paymentName";
-            this.comboBox_paymentName.Size = new System.Drawing.Size(227, 25);
-            this.comboBox_paymentName.TabIndex = 17;
+            comboBox_paymentName.FormattingEnabled = true;
+            comboBox_paymentName.Location = new System.Drawing.Point(196, 462);
+            comboBox_paymentName.Name = "comboBox_paymentName";
+            comboBox_paymentName.Size = new System.Drawing.Size(160, 25);
+            comboBox_paymentName.TabIndex = 17;
             // 
             // comboBox_paymentProductNo
             // 
-            this.comboBox_paymentProductNo.FormattingEnabled = true;
-            this.comboBox_paymentProductNo.Location = new System.Drawing.Point(280, 719);
-            this.comboBox_paymentProductNo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_paymentProductNo.Name = "comboBox_paymentProductNo";
-            this.comboBox_paymentProductNo.Size = new System.Drawing.Size(227, 25);
-            this.comboBox_paymentProductNo.TabIndex = 16;
+            comboBox_paymentProductNo.FormattingEnabled = true;
+            comboBox_paymentProductNo.Location = new System.Drawing.Point(196, 431);
+            comboBox_paymentProductNo.Name = "comboBox_paymentProductNo";
+            comboBox_paymentProductNo.Size = new System.Drawing.Size(160, 25);
+            comboBox_paymentProductNo.TabIndex = 16;
             // 
             // comboBox_taskHourlyRate
             // 
-            this.comboBox_taskHourlyRate.FormattingEnabled = true;
-            this.comboBox_taskHourlyRate.Location = new System.Drawing.Point(280, 667);
-            this.comboBox_taskHourlyRate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_taskHourlyRate.Name = "comboBox_taskHourlyRate";
-            this.comboBox_taskHourlyRate.Size = new System.Drawing.Size(227, 25);
-            this.comboBox_taskHourlyRate.TabIndex = 15;
+            comboBox_taskHourlyRate.FormattingEnabled = true;
+            comboBox_taskHourlyRate.Location = new System.Drawing.Point(196, 400);
+            comboBox_taskHourlyRate.Name = "comboBox_taskHourlyRate";
+            comboBox_taskHourlyRate.Size = new System.Drawing.Size(160, 25);
+            comboBox_taskHourlyRate.TabIndex = 15;
             // 
             // label_taskHourlyRate
             // 
-            this.label_taskHourlyRate.AutoSize = true;
-            this.label_taskHourlyRate.Location = new System.Drawing.Point(14, 672);
-            this.label_taskHourlyRate.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_taskHourlyRate.Name = "label_taskHourlyRate";
-            this.label_taskHourlyRate.Size = new System.Drawing.Size(110, 17);
-            this.label_taskHourlyRate.TabIndex = 1;
-            this.label_taskHourlyRate.Text = "Task Hourly Rate";
+            label_taskHourlyRate.AutoSize = true;
+            label_taskHourlyRate.Location = new System.Drawing.Point(10, 403);
+            label_taskHourlyRate.Name = "label_taskHourlyRate";
+            label_taskHourlyRate.Size = new System.Drawing.Size(110, 17);
+            label_taskHourlyRate.TabIndex = 1;
+            label_taskHourlyRate.Text = "Task Hourly Rate";
             // 
             // checkBox_defaultPaymentRecognitionModel
             // 
-            this.checkBox_defaultPaymentRecognitionModel.AutoSize = true;
-            this.checkBox_defaultPaymentRecognitionModel.Location = new System.Drawing.Point(517, 567);
-            this.checkBox_defaultPaymentRecognitionModel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultPaymentRecognitionModel.Name = "checkBox_defaultPaymentRecognitionModel";
-            this.checkBox_defaultPaymentRecognitionModel.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultPaymentRecognitionModel.TabIndex = 12;
-            this.checkBox_defaultPaymentRecognitionModel.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultPaymentRecognitionModel, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultPaymentRecognitionModel.UseVisualStyleBackColor = true;
-            this.checkBox_defaultPaymentRecognitionModel.CheckedChanged += new System.EventHandler(this.checkBox_defaultPaymentRecognitionModel_CheckedChanged);
+            checkBox_defaultPaymentRecognitionModel.AutoSize = true;
+            checkBox_defaultPaymentRecognitionModel.Location = new System.Drawing.Point(362, 340);
+            checkBox_defaultPaymentRecognitionModel.Name = "checkBox_defaultPaymentRecognitionModel";
+            checkBox_defaultPaymentRecognitionModel.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultPaymentRecognitionModel.TabIndex = 12;
+            checkBox_defaultPaymentRecognitionModel.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultPaymentRecognitionModel, "Set default values for all rows of a particular column field");
+            checkBox_defaultPaymentRecognitionModel.UseVisualStyleBackColor = true;
+            checkBox_defaultPaymentRecognitionModel.CheckedChanged += checkBox_defaultPaymentRecognitionModel_CheckedChanged;
             // 
             // checkBox_defaultIsBillable
             // 
-            this.checkBox_defaultIsBillable.AutoSize = true;
-            this.checkBox_defaultIsBillable.Location = new System.Drawing.Point(517, 428);
-            this.checkBox_defaultIsBillable.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultIsBillable.Name = "checkBox_defaultIsBillable";
-            this.checkBox_defaultIsBillable.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultIsBillable.TabIndex = 14;
-            this.checkBox_defaultIsBillable.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultIsBillable, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultIsBillable.UseVisualStyleBackColor = true;
-            this.checkBox_defaultIsBillable.CheckedChanged += new System.EventHandler(this.checkBox_defaultIsBillable_CheckedChanged);
+            checkBox_defaultIsBillable.AutoSize = true;
+            checkBox_defaultIsBillable.Location = new System.Drawing.Point(362, 257);
+            checkBox_defaultIsBillable.Name = "checkBox_defaultIsBillable";
+            checkBox_defaultIsBillable.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultIsBillable.TabIndex = 14;
+            checkBox_defaultIsBillable.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultIsBillable, "Set default values for all rows of a particular column field");
+            checkBox_defaultIsBillable.UseVisualStyleBackColor = true;
+            checkBox_defaultIsBillable.CheckedChanged += checkBox_defaultIsBillable_CheckedChanged;
             // 
             // label_paymentRecognitionModel
             // 
-            this.label_paymentRecognitionModel.AutoSize = true;
-            this.label_paymentRecognitionModel.Location = new System.Drawing.Point(14, 569);
-            this.label_paymentRecognitionModel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_paymentRecognitionModel.Name = "label_paymentRecognitionModel";
-            this.label_paymentRecognitionModel.Size = new System.Drawing.Size(180, 17);
-            this.label_paymentRecognitionModel.TabIndex = 1;
-            this.label_paymentRecognitionModel.Text = "Payment Recognition Model";
+            label_paymentRecognitionModel.AutoSize = true;
+            label_paymentRecognitionModel.Location = new System.Drawing.Point(10, 341);
+            label_paymentRecognitionModel.Name = "label_paymentRecognitionModel";
+            label_paymentRecognitionModel.Size = new System.Drawing.Size(180, 17);
+            label_paymentRecognitionModel.TabIndex = 1;
+            label_paymentRecognitionModel.Text = "Payment Recognition Model";
             // 
             // comboBox_budgetAmount
             // 
-            this.comboBox_budgetAmount.FormattingEnabled = true;
-            this.comboBox_budgetAmount.Location = new System.Drawing.Point(280, 218);
-            this.comboBox_budgetAmount.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_budgetAmount.Name = "comboBox_budgetAmount";
-            this.comboBox_budgetAmount.Size = new System.Drawing.Size(227, 25);
-            this.comboBox_budgetAmount.TabIndex = 10;
+            comboBox_budgetAmount.FormattingEnabled = true;
+            comboBox_budgetAmount.Location = new System.Drawing.Point(196, 131);
+            comboBox_budgetAmount.Name = "comboBox_budgetAmount";
+            comboBox_budgetAmount.Size = new System.Drawing.Size(160, 25);
+            comboBox_budgetAmount.TabIndex = 10;
             // 
             // comboBox_paymentRecognitionModel
             // 
-            this.comboBox_paymentRecognitionModel.FormattingEnabled = true;
-            this.comboBox_paymentRecognitionModel.Location = new System.Drawing.Point(280, 564);
-            this.comboBox_paymentRecognitionModel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_paymentRecognitionModel.Name = "comboBox_paymentRecognitionModel";
-            this.comboBox_paymentRecognitionModel.Size = new System.Drawing.Size(227, 25);
-            this.comboBox_paymentRecognitionModel.TabIndex = 9;
+            comboBox_paymentRecognitionModel.FormattingEnabled = true;
+            comboBox_paymentRecognitionModel.Location = new System.Drawing.Point(196, 338);
+            comboBox_paymentRecognitionModel.Name = "comboBox_paymentRecognitionModel";
+            comboBox_paymentRecognitionModel.Size = new System.Drawing.Size(160, 25);
+            comboBox_paymentRecognitionModel.TabIndex = 9;
             // 
             // comboBox_paymentAmount
             // 
-            this.comboBox_paymentAmount.FormattingEnabled = true;
-            this.comboBox_paymentAmount.Location = new System.Drawing.Point(280, 615);
-            this.comboBox_paymentAmount.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_paymentAmount.Name = "comboBox_paymentAmount";
-            this.comboBox_paymentAmount.Size = new System.Drawing.Size(227, 25);
-            this.comboBox_paymentAmount.TabIndex = 3;
+            comboBox_paymentAmount.FormattingEnabled = true;
+            comboBox_paymentAmount.Location = new System.Drawing.Point(196, 369);
+            comboBox_paymentAmount.Name = "comboBox_paymentAmount";
+            comboBox_paymentAmount.Size = new System.Drawing.Size(160, 25);
+            comboBox_paymentAmount.TabIndex = 3;
             // 
             // label_isBillable
             // 
-            this.label_isBillable.AutoSize = true;
-            this.label_isBillable.Location = new System.Drawing.Point(14, 430);
-            this.label_isBillable.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_isBillable.Name = "label_isBillable";
-            this.label_isBillable.Size = new System.Drawing.Size(64, 17);
-            this.label_isBillable.TabIndex = 1;
-            this.label_isBillable.Text = "Is Billable";
+            label_isBillable.AutoSize = true;
+            label_isBillable.Location = new System.Drawing.Point(10, 258);
+            label_isBillable.Name = "label_isBillable";
+            label_isBillable.Size = new System.Drawing.Size(64, 17);
+            label_isBillable.TabIndex = 1;
+            label_isBillable.Text = "Is Billable";
             // 
             // label_paymentAmount
             // 
-            this.label_paymentAmount.AutoSize = true;
-            this.label_paymentAmount.Location = new System.Drawing.Point(14, 620);
-            this.label_paymentAmount.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_paymentAmount.Name = "label_paymentAmount";
-            this.label_paymentAmount.Size = new System.Drawing.Size(116, 17);
-            this.label_paymentAmount.TabIndex = 1;
-            this.label_paymentAmount.Text = "Payment Amount";
+            label_paymentAmount.AutoSize = true;
+            label_paymentAmount.Location = new System.Drawing.Point(10, 372);
+            label_paymentAmount.Name = "label_paymentAmount";
+            label_paymentAmount.Size = new System.Drawing.Size(116, 17);
+            label_paymentAmount.TabIndex = 1;
+            label_paymentAmount.Text = "Payment Amount";
             // 
             // label_budgetAmount
             // 
-            this.label_budgetAmount.AutoSize = true;
-            this.label_budgetAmount.Location = new System.Drawing.Point(14, 223);
-            this.label_budgetAmount.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_budgetAmount.Name = "label_budgetAmount";
-            this.label_budgetAmount.Size = new System.Drawing.Size(106, 17);
-            this.label_budgetAmount.TabIndex = 1;
-            this.label_budgetAmount.Text = "Budget Amount";
+            label_budgetAmount.AutoSize = true;
+            label_budgetAmount.Location = new System.Drawing.Point(10, 134);
+            label_budgetAmount.Name = "label_budgetAmount";
+            label_budgetAmount.Size = new System.Drawing.Size(106, 17);
+            label_budgetAmount.TabIndex = 1;
+            label_budgetAmount.Text = "Budget Amount";
             // 
             // comboBox_isBillable
             // 
-            this.comboBox_isBillable.FormattingEnabled = true;
-            this.comboBox_isBillable.Location = new System.Drawing.Point(280, 425);
-            this.comboBox_isBillable.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_isBillable.Name = "comboBox_isBillable";
-            this.comboBox_isBillable.Size = new System.Drawing.Size(227, 25);
-            this.comboBox_isBillable.TabIndex = 8;
+            comboBox_isBillable.FormattingEnabled = true;
+            comboBox_isBillable.Location = new System.Drawing.Point(196, 255);
+            comboBox_isBillable.Name = "comboBox_isBillable";
+            comboBox_isBillable.Size = new System.Drawing.Size(160, 25);
+            comboBox_isBillable.TabIndex = 8;
             // 
             // label_taskNo
             // 
-            this.label_taskNo.AutoSize = true;
-            this.label_taskNo.Location = new System.Drawing.Point(14, 17);
-            this.label_taskNo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_taskNo.Name = "label_taskNo";
-            this.label_taskNo.Size = new System.Drawing.Size(56, 17);
-            this.label_taskNo.TabIndex = 1;
-            this.label_taskNo.Text = "Task No";
+            label_taskNo.AutoSize = true;
+            label_taskNo.Location = new System.Drawing.Point(10, 10);
+            label_taskNo.Name = "label_taskNo";
+            label_taskNo.Size = new System.Drawing.Size(56, 17);
+            label_taskNo.TabIndex = 1;
+            label_taskNo.Text = "Task No";
             // 
             // label_hourlyRate
             // 
-            this.label_hourlyRate.AutoSize = true;
-            this.label_hourlyRate.Location = new System.Drawing.Point(14, 327);
-            this.label_hourlyRate.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_hourlyRate.Name = "label_hourlyRate";
-            this.label_hourlyRate.Size = new System.Drawing.Size(80, 17);
-            this.label_hourlyRate.TabIndex = 1;
-            this.label_hourlyRate.Text = "Hourly Rate";
-            this.defaultToolTip.SetToolTip(this.label_hourlyRate, "In expense currency");
+            label_hourlyRate.AutoSize = true;
+            label_hourlyRate.Location = new System.Drawing.Point(10, 196);
+            label_hourlyRate.Name = "label_hourlyRate";
+            label_hourlyRate.Size = new System.Drawing.Size(80, 17);
+            label_hourlyRate.TabIndex = 1;
+            label_hourlyRate.Text = "Hourly Rate";
+            defaultToolTip.SetToolTip(label_hourlyRate, "In expense currency");
             // 
             // comboBox_parentTaskNo
             // 
-            this.comboBox_parentTaskNo.FormattingEnabled = true;
-            this.comboBox_parentTaskNo.Location = new System.Drawing.Point(280, 373);
-            this.comboBox_parentTaskNo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_parentTaskNo.Name = "comboBox_parentTaskNo";
-            this.comboBox_parentTaskNo.Size = new System.Drawing.Size(227, 25);
-            this.comboBox_parentTaskNo.TabIndex = 7;
+            comboBox_parentTaskNo.FormattingEnabled = true;
+            comboBox_parentTaskNo.Location = new System.Drawing.Point(196, 224);
+            comboBox_parentTaskNo.Name = "comboBox_parentTaskNo";
+            comboBox_parentTaskNo.Size = new System.Drawing.Size(160, 25);
+            comboBox_parentTaskNo.TabIndex = 7;
             // 
             // label_parentTaskNo
             // 
-            this.label_parentTaskNo.AutoSize = true;
-            this.label_parentTaskNo.Location = new System.Drawing.Point(14, 378);
-            this.label_parentTaskNo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_parentTaskNo.Name = "label_parentTaskNo";
-            this.label_parentTaskNo.Size = new System.Drawing.Size(100, 17);
-            this.label_parentTaskNo.TabIndex = 1;
-            this.label_parentTaskNo.Text = "Parent Task No";
+            label_parentTaskNo.AutoSize = true;
+            label_parentTaskNo.Location = new System.Drawing.Point(10, 227);
+            label_parentTaskNo.Name = "label_parentTaskNo";
+            label_parentTaskNo.Size = new System.Drawing.Size(100, 17);
+            label_parentTaskNo.TabIndex = 1;
+            label_parentTaskNo.Text = "Parent Task No";
             // 
             // comboBox_taskNo
             // 
-            this.comboBox_taskNo.FormattingEnabled = true;
-            this.comboBox_taskNo.Location = new System.Drawing.Point(280, 12);
-            this.comboBox_taskNo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_taskNo.Name = "comboBox_taskNo";
-            this.comboBox_taskNo.Size = new System.Drawing.Size(227, 25);
-            this.comboBox_taskNo.TabIndex = 3;
+            comboBox_taskNo.FormattingEnabled = true;
+            comboBox_taskNo.Location = new System.Drawing.Point(196, 7);
+            comboBox_taskNo.Name = "comboBox_taskNo";
+            comboBox_taskNo.Size = new System.Drawing.Size(160, 25);
+            comboBox_taskNo.TabIndex = 3;
             // 
             // label_budgetHours
             // 
-            this.label_budgetHours.AutoSize = true;
-            this.label_budgetHours.Location = new System.Drawing.Point(14, 172);
-            this.label_budgetHours.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_budgetHours.Name = "label_budgetHours";
-            this.label_budgetHours.Size = new System.Drawing.Size(93, 17);
-            this.label_budgetHours.TabIndex = 1;
-            this.label_budgetHours.Text = "Budget Hours";
+            label_budgetHours.AutoSize = true;
+            label_budgetHours.Location = new System.Drawing.Point(10, 103);
+            label_budgetHours.Name = "label_budgetHours";
+            label_budgetHours.Size = new System.Drawing.Size(93, 17);
+            label_budgetHours.TabIndex = 1;
+            label_budgetHours.Text = "Budget Hours";
             // 
             // comboBox_budgetHours
             // 
-            this.comboBox_budgetHours.FormattingEnabled = true;
-            this.comboBox_budgetHours.Location = new System.Drawing.Point(280, 167);
-            this.comboBox_budgetHours.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_budgetHours.Name = "comboBox_budgetHours";
-            this.comboBox_budgetHours.Size = new System.Drawing.Size(227, 25);
-            this.comboBox_budgetHours.TabIndex = 3;
+            comboBox_budgetHours.FormattingEnabled = true;
+            comboBox_budgetHours.Location = new System.Drawing.Point(196, 100);
+            comboBox_budgetHours.Name = "comboBox_budgetHours";
+            comboBox_budgetHours.Size = new System.Drawing.Size(160, 25);
+            comboBox_budgetHours.TabIndex = 3;
             // 
             // checkBox_defaultIsReadyForInvoicing
             // 
-            this.checkBox_defaultIsReadyForInvoicing.AutoSize = true;
-            this.checkBox_defaultIsReadyForInvoicing.Location = new System.Drawing.Point(517, 273);
-            this.checkBox_defaultIsReadyForInvoicing.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultIsReadyForInvoicing.Name = "checkBox_defaultIsReadyForInvoicing";
-            this.checkBox_defaultIsReadyForInvoicing.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultIsReadyForInvoicing.TabIndex = 6;
-            this.checkBox_defaultIsReadyForInvoicing.Text = "Default";
-            this.defaultToolTip.SetToolTip(this.checkBox_defaultIsReadyForInvoicing, "Set default values for all rows of a particular column field");
-            this.checkBox_defaultIsReadyForInvoicing.UseVisualStyleBackColor = true;
-            this.checkBox_defaultIsReadyForInvoicing.CheckedChanged += new System.EventHandler(this.checkBox_defaultIsReadyForInvoicing_CheckedChanged);
+            checkBox_defaultIsReadyForInvoicing.AutoSize = true;
+            checkBox_defaultIsReadyForInvoicing.Location = new System.Drawing.Point(362, 164);
+            checkBox_defaultIsReadyForInvoicing.Name = "checkBox_defaultIsReadyForInvoicing";
+            checkBox_defaultIsReadyForInvoicing.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultIsReadyForInvoicing.TabIndex = 6;
+            checkBox_defaultIsReadyForInvoicing.Text = "Default";
+            defaultToolTip.SetToolTip(checkBox_defaultIsReadyForInvoicing, "Set default values for all rows of a particular column field");
+            checkBox_defaultIsReadyForInvoicing.UseVisualStyleBackColor = true;
+            checkBox_defaultIsReadyForInvoicing.CheckedChanged += checkBox_defaultIsReadyForInvoicing_CheckedChanged;
             // 
             // label_isReadyForInvoicing
             // 
-            this.label_isReadyForInvoicing.AutoSize = true;
-            this.label_isReadyForInvoicing.Location = new System.Drawing.Point(14, 275);
-            this.label_isReadyForInvoicing.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_isReadyForInvoicing.Name = "label_isReadyForInvoicing";
-            this.label_isReadyForInvoicing.Size = new System.Drawing.Size(142, 17);
-            this.label_isReadyForInvoicing.TabIndex = 1;
-            this.label_isReadyForInvoicing.Text = "Is Ready For Invoicing";
+            label_isReadyForInvoicing.AutoSize = true;
+            label_isReadyForInvoicing.Location = new System.Drawing.Point(10, 165);
+            label_isReadyForInvoicing.Name = "label_isReadyForInvoicing";
+            label_isReadyForInvoicing.Size = new System.Drawing.Size(142, 17);
+            label_isReadyForInvoicing.TabIndex = 1;
+            label_isReadyForInvoicing.Text = "Is Ready For Invoicing";
             // 
             // comboBox_description
             // 
-            this.comboBox_description.FormattingEnabled = true;
-            this.comboBox_description.Location = new System.Drawing.Point(280, 63);
-            this.comboBox_description.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_description.Name = "comboBox_description";
-            this.comboBox_description.Size = new System.Drawing.Size(227, 25);
-            this.comboBox_description.TabIndex = 3;
+            comboBox_description.FormattingEnabled = true;
+            comboBox_description.Location = new System.Drawing.Point(196, 38);
+            comboBox_description.Name = "comboBox_description";
+            comboBox_description.Size = new System.Drawing.Size(160, 25);
+            comboBox_description.TabIndex = 3;
             // 
             // comboBox_isReadyForInvoicing
             // 
-            this.comboBox_isReadyForInvoicing.FormattingEnabled = true;
-            this.comboBox_isReadyForInvoicing.Location = new System.Drawing.Point(280, 270);
-            this.comboBox_isReadyForInvoicing.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_isReadyForInvoicing.Name = "comboBox_isReadyForInvoicing";
-            this.comboBox_isReadyForInvoicing.Size = new System.Drawing.Size(227, 25);
-            this.comboBox_isReadyForInvoicing.TabIndex = 3;
+            comboBox_isReadyForInvoicing.FormattingEnabled = true;
+            comboBox_isReadyForInvoicing.Location = new System.Drawing.Point(196, 162);
+            comboBox_isReadyForInvoicing.Name = "comboBox_isReadyForInvoicing";
+            comboBox_isReadyForInvoicing.Size = new System.Drawing.Size(160, 25);
+            comboBox_isReadyForInvoicing.TabIndex = 3;
             // 
             // label_description
             // 
-            this.label_description.AutoSize = true;
-            this.label_description.Location = new System.Drawing.Point(14, 68);
-            this.label_description.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_description.Name = "label_description";
-            this.label_description.Size = new System.Drawing.Size(76, 17);
-            this.label_description.TabIndex = 1;
-            this.label_description.Text = "Description";
+            label_description.AutoSize = true;
+            label_description.Location = new System.Drawing.Point(10, 41);
+            label_description.Name = "label_description";
+            label_description.Size = new System.Drawing.Size(76, 17);
+            label_description.TabIndex = 1;
+            label_description.Text = "Description";
             // 
             // label_additionalTextIsRequired
             // 
-            this.label_additionalTextIsRequired.AutoSize = true;
-            this.label_additionalTextIsRequired.Location = new System.Drawing.Point(14, 120);
-            this.label_additionalTextIsRequired.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_additionalTextIsRequired.Name = "label_additionalTextIsRequired";
-            this.label_additionalTextIsRequired.Size = new System.Drawing.Size(137, 17);
-            this.label_additionalTextIsRequired.TabIndex = 1;
-            this.label_additionalTextIsRequired.Text = "Add. Text Is Required";
+            label_additionalTextIsRequired.AutoSize = true;
+            label_additionalTextIsRequired.Location = new System.Drawing.Point(10, 72);
+            label_additionalTextIsRequired.Name = "label_additionalTextIsRequired";
+            label_additionalTextIsRequired.Size = new System.Drawing.Size(137, 17);
+            label_additionalTextIsRequired.TabIndex = 1;
+            label_additionalTextIsRequired.Text = "Add. Text Is Required";
             // 
             // comboBox_additionalTextIsRequired
             // 
-            this.comboBox_additionalTextIsRequired.FormattingEnabled = true;
-            this.comboBox_additionalTextIsRequired.Location = new System.Drawing.Point(280, 115);
-            this.comboBox_additionalTextIsRequired.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_additionalTextIsRequired.Name = "comboBox_additionalTextIsRequired";
-            this.comboBox_additionalTextIsRequired.Size = new System.Drawing.Size(227, 25);
-            this.comboBox_additionalTextIsRequired.TabIndex = 3;
+            comboBox_additionalTextIsRequired.FormattingEnabled = true;
+            comboBox_additionalTextIsRequired.Location = new System.Drawing.Point(196, 69);
+            comboBox_additionalTextIsRequired.Name = "comboBox_additionalTextIsRequired";
+            comboBox_additionalTextIsRequired.Size = new System.Drawing.Size(160, 25);
+            comboBox_additionalTextIsRequired.TabIndex = 3;
             // 
             // comboBox_hourlyRate
             // 
-            this.comboBox_hourlyRate.FormattingEnabled = true;
-            this.comboBox_hourlyRate.Location = new System.Drawing.Point(280, 322);
-            this.comboBox_hourlyRate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_hourlyRate.Name = "comboBox_hourlyRate";
-            this.comboBox_hourlyRate.Size = new System.Drawing.Size(227, 25);
-            this.comboBox_hourlyRate.TabIndex = 3;
+            comboBox_hourlyRate.FormattingEnabled = true;
+            comboBox_hourlyRate.Location = new System.Drawing.Point(196, 193);
+            comboBox_hourlyRate.Name = "comboBox_hourlyRate";
+            comboBox_hourlyRate.Size = new System.Drawing.Size(160, 25);
+            comboBox_hourlyRate.TabIndex = 3;
             // 
             // label_delimiter
             // 
-            this.label_delimiter.AutoSize = true;
-            this.label_delimiter.Location = new System.Drawing.Point(14, 125);
-            this.label_delimiter.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_delimiter.Name = "label_delimiter";
-            this.label_delimiter.Size = new System.Drawing.Size(62, 17);
-            this.label_delimiter.TabIndex = 1;
-            this.label_delimiter.Text = "Delimiter";
+            label_delimiter.AutoSize = true;
+            label_delimiter.Location = new System.Drawing.Point(10, 75);
+            label_delimiter.Name = "label_delimiter";
+            label_delimiter.Size = new System.Drawing.Size(62, 17);
+            label_delimiter.TabIndex = 1;
+            label_delimiter.Text = "Delimiter";
             // 
             // comboBox_delimiter
             // 
-            this.comboBox_delimiter.FormattingEnabled = true;
-            this.comboBox_delimiter.Location = new System.Drawing.Point(117, 120);
-            this.comboBox_delimiter.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_delimiter.Name = "comboBox_delimiter";
-            this.comboBox_delimiter.Size = new System.Drawing.Size(78, 25);
-            this.comboBox_delimiter.TabIndex = 6;
+            comboBox_delimiter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboBox_delimiter.FormattingEnabled = true;
+            comboBox_delimiter.Location = new System.Drawing.Point(82, 72);
+            comboBox_delimiter.Name = "comboBox_delimiter";
+            comboBox_delimiter.Size = new System.Drawing.Size(56, 25);
+            comboBox_delimiter.TabIndex = 6;
             // 
             // groupBox_taskMandatoryFields
             // 
-            this.groupBox_taskMandatoryFields.Controls.Add(this.checkBox_defaultTaskType);
-            this.groupBox_taskMandatoryFields.Controls.Add(this.comboBox_contractName);
-            this.groupBox_taskMandatoryFields.Controls.Add(this.label_contractName);
-            this.groupBox_taskMandatoryFields.Controls.Add(this.label_projectNo);
-            this.groupBox_taskMandatoryFields.Controls.Add(this.comboBox_projectNo);
-            this.groupBox_taskMandatoryFields.Controls.Add(this.label_taskType);
-            this.groupBox_taskMandatoryFields.Controls.Add(this.comboBox_taskType);
-            this.groupBox_taskMandatoryFields.Controls.Add(this.label_endDate);
-            this.groupBox_taskMandatoryFields.Controls.Add(this.comboBox_endDate);
-            this.groupBox_taskMandatoryFields.Controls.Add(this.label_startDate);
-            this.groupBox_taskMandatoryFields.Controls.Add(this.comboBox_startDate);
-            this.groupBox_taskMandatoryFields.Controls.Add(this.label_taskName);
-            this.groupBox_taskMandatoryFields.Controls.Add(this.comboBox_taskName);
-            this.groupBox_taskMandatoryFields.Location = new System.Drawing.Point(213, 103);
-            this.groupBox_taskMandatoryFields.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.groupBox_taskMandatoryFields.Name = "groupBox_taskMandatoryFields";
-            this.groupBox_taskMandatoryFields.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.groupBox_taskMandatoryFields.Size = new System.Drawing.Size(523, 368);
-            this.groupBox_taskMandatoryFields.TabIndex = 5;
-            this.groupBox_taskMandatoryFields.TabStop = false;
-            this.groupBox_taskMandatoryFields.Text = "Mandatory";
+            groupBox_taskMandatoryFields.Controls.Add(checkBox_defaultTaskType);
+            groupBox_taskMandatoryFields.Controls.Add(comboBox_contractName);
+            groupBox_taskMandatoryFields.Controls.Add(label_contractName);
+            groupBox_taskMandatoryFields.Controls.Add(label_projectNo);
+            groupBox_taskMandatoryFields.Controls.Add(comboBox_projectNo);
+            groupBox_taskMandatoryFields.Controls.Add(label_taskType);
+            groupBox_taskMandatoryFields.Controls.Add(comboBox_taskType);
+            groupBox_taskMandatoryFields.Controls.Add(label_endDate);
+            groupBox_taskMandatoryFields.Controls.Add(comboBox_endDate);
+            groupBox_taskMandatoryFields.Controls.Add(label_startDate);
+            groupBox_taskMandatoryFields.Controls.Add(comboBox_startDate);
+            groupBox_taskMandatoryFields.Controls.Add(label_taskName);
+            groupBox_taskMandatoryFields.Controls.Add(comboBox_taskName);
+            groupBox_taskMandatoryFields.Location = new System.Drawing.Point(149, 62);
+            groupBox_taskMandatoryFields.Name = "groupBox_taskMandatoryFields";
+            groupBox_taskMandatoryFields.Size = new System.Drawing.Size(366, 221);
+            groupBox_taskMandatoryFields.TabIndex = 5;
+            groupBox_taskMandatoryFields.TabStop = false;
+            groupBox_taskMandatoryFields.Text = "Mandatory";
             // 
             // checkBox_defaultTaskType
             // 
-            this.checkBox_defaultTaskType.AutoSize = true;
-            this.checkBox_defaultTaskType.Location = new System.Drawing.Point(421, 250);
-            this.checkBox_defaultTaskType.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBox_defaultTaskType.Name = "checkBox_defaultTaskType";
-            this.checkBox_defaultTaskType.Size = new System.Drawing.Size(70, 21);
-            this.checkBox_defaultTaskType.TabIndex = 11;
-            this.checkBox_defaultTaskType.Text = "Default";
-            this.checkBox_defaultTaskType.UseVisualStyleBackColor = true;
-            this.checkBox_defaultTaskType.CheckedChanged += new System.EventHandler(this.checkBox_defaultTaskType_CheckedChanged);
+            checkBox_defaultTaskType.AutoSize = true;
+            checkBox_defaultTaskType.Location = new System.Drawing.Point(295, 150);
+            checkBox_defaultTaskType.Name = "checkBox_defaultTaskType";
+            checkBox_defaultTaskType.Size = new System.Drawing.Size(70, 21);
+            checkBox_defaultTaskType.TabIndex = 11;
+            checkBox_defaultTaskType.Text = "Default";
+            checkBox_defaultTaskType.UseVisualStyleBackColor = true;
+            checkBox_defaultTaskType.CheckedChanged += checkBox_defaultTaskType_CheckedChanged;
             // 
             // comboBox_contractName
             // 
-            this.comboBox_contractName.FormattingEnabled = true;
-            this.comboBox_contractName.Location = new System.Drawing.Point(193, 195);
-            this.comboBox_contractName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_contractName.Name = "comboBox_contractName";
-            this.comboBox_contractName.Size = new System.Drawing.Size(218, 25);
-            this.comboBox_contractName.TabIndex = 10;
+            comboBox_contractName.FormattingEnabled = true;
+            comboBox_contractName.Location = new System.Drawing.Point(135, 117);
+            comboBox_contractName.Name = "comboBox_contractName";
+            comboBox_contractName.Size = new System.Drawing.Size(154, 25);
+            comboBox_contractName.TabIndex = 10;
             // 
             // label_contractName
             // 
-            this.label_contractName.AutoSize = true;
-            this.label_contractName.Location = new System.Drawing.Point(9, 200);
-            this.label_contractName.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_contractName.Name = "label_contractName";
-            this.label_contractName.Size = new System.Drawing.Size(100, 17);
-            this.label_contractName.TabIndex = 1;
-            this.label_contractName.Text = "Contract Name";
+            label_contractName.AutoSize = true;
+            label_contractName.Location = new System.Drawing.Point(6, 120);
+            label_contractName.Name = "label_contractName";
+            label_contractName.Size = new System.Drawing.Size(100, 17);
+            label_contractName.TabIndex = 1;
+            label_contractName.Text = "Contract Name";
             // 
             // label_projectNo
             // 
-            this.label_projectNo.AutoSize = true;
-            this.label_projectNo.Location = new System.Drawing.Point(9, 303);
-            this.label_projectNo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_projectNo.Name = "label_projectNo";
-            this.label_projectNo.Size = new System.Drawing.Size(72, 17);
-            this.label_projectNo.TabIndex = 1;
-            this.label_projectNo.Text = "Project No";
-            this.defaultToolTip.SetToolTip(this.label_projectNo, "In project currency");
+            label_projectNo.AutoSize = true;
+            label_projectNo.Location = new System.Drawing.Point(6, 182);
+            label_projectNo.Name = "label_projectNo";
+            label_projectNo.Size = new System.Drawing.Size(72, 17);
+            label_projectNo.TabIndex = 1;
+            label_projectNo.Text = "Project No";
+            defaultToolTip.SetToolTip(label_projectNo, "In project currency");
             // 
             // comboBox_projectNo
             // 
-            this.comboBox_projectNo.FormattingEnabled = true;
-            this.comboBox_projectNo.Location = new System.Drawing.Point(193, 298);
-            this.comboBox_projectNo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_projectNo.Name = "comboBox_projectNo";
-            this.comboBox_projectNo.Size = new System.Drawing.Size(218, 25);
-            this.comboBox_projectNo.TabIndex = 3;
+            comboBox_projectNo.FormattingEnabled = true;
+            comboBox_projectNo.Location = new System.Drawing.Point(135, 179);
+            comboBox_projectNo.Name = "comboBox_projectNo";
+            comboBox_projectNo.Size = new System.Drawing.Size(154, 25);
+            comboBox_projectNo.TabIndex = 3;
             // 
             // label_taskType
             // 
-            this.label_taskType.AutoSize = true;
-            this.label_taskType.Location = new System.Drawing.Point(9, 252);
-            this.label_taskType.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_taskType.Name = "label_taskType";
-            this.label_taskType.Size = new System.Drawing.Size(66, 17);
-            this.label_taskType.TabIndex = 1;
-            this.label_taskType.Text = "Task Type";
-            this.defaultToolTip.SetToolTip(this.label_taskType, "In expense currency");
+            label_taskType.AutoSize = true;
+            label_taskType.Location = new System.Drawing.Point(6, 151);
+            label_taskType.Name = "label_taskType";
+            label_taskType.Size = new System.Drawing.Size(66, 17);
+            label_taskType.TabIndex = 1;
+            label_taskType.Text = "Task Type";
+            defaultToolTip.SetToolTip(label_taskType, "In expense currency");
             // 
             // comboBox_taskType
             // 
-            this.comboBox_taskType.FormattingEnabled = true;
-            this.comboBox_taskType.Location = new System.Drawing.Point(193, 247);
-            this.comboBox_taskType.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_taskType.Name = "comboBox_taskType";
-            this.comboBox_taskType.Size = new System.Drawing.Size(218, 25);
-            this.comboBox_taskType.TabIndex = 3;
+            comboBox_taskType.FormattingEnabled = true;
+            comboBox_taskType.Location = new System.Drawing.Point(135, 148);
+            comboBox_taskType.Name = "comboBox_taskType";
+            comboBox_taskType.Size = new System.Drawing.Size(154, 25);
+            comboBox_taskType.TabIndex = 3;
             // 
             // label_endDate
             // 
-            this.label_endDate.AutoSize = true;
-            this.label_endDate.Location = new System.Drawing.Point(9, 148);
-            this.label_endDate.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_endDate.Name = "label_endDate";
-            this.label_endDate.Size = new System.Drawing.Size(63, 17);
-            this.label_endDate.TabIndex = 1;
-            this.label_endDate.Text = "End Date";
+            label_endDate.AutoSize = true;
+            label_endDate.Location = new System.Drawing.Point(6, 89);
+            label_endDate.Name = "label_endDate";
+            label_endDate.Size = new System.Drawing.Size(63, 17);
+            label_endDate.TabIndex = 1;
+            label_endDate.Text = "End Date";
             // 
             // comboBox_endDate
             // 
-            this.comboBox_endDate.FormattingEnabled = true;
-            this.comboBox_endDate.Location = new System.Drawing.Point(193, 143);
-            this.comboBox_endDate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_endDate.Name = "comboBox_endDate";
-            this.comboBox_endDate.Size = new System.Drawing.Size(218, 25);
-            this.comboBox_endDate.TabIndex = 3;
+            comboBox_endDate.FormattingEnabled = true;
+            comboBox_endDate.Location = new System.Drawing.Point(135, 86);
+            comboBox_endDate.Name = "comboBox_endDate";
+            comboBox_endDate.Size = new System.Drawing.Size(154, 25);
+            comboBox_endDate.TabIndex = 3;
             // 
             // label_startDate
             // 
-            this.label_startDate.AutoSize = true;
-            this.label_startDate.Location = new System.Drawing.Point(9, 97);
-            this.label_startDate.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_startDate.Name = "label_startDate";
-            this.label_startDate.Size = new System.Drawing.Size(69, 17);
-            this.label_startDate.TabIndex = 1;
-            this.label_startDate.Text = "Start Date";
+            label_startDate.AutoSize = true;
+            label_startDate.Location = new System.Drawing.Point(6, 58);
+            label_startDate.Name = "label_startDate";
+            label_startDate.Size = new System.Drawing.Size(69, 17);
+            label_startDate.TabIndex = 1;
+            label_startDate.Text = "Start Date";
             // 
             // comboBox_startDate
             // 
-            this.comboBox_startDate.FormattingEnabled = true;
-            this.comboBox_startDate.Location = new System.Drawing.Point(193, 92);
-            this.comboBox_startDate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_startDate.Name = "comboBox_startDate";
-            this.comboBox_startDate.Size = new System.Drawing.Size(218, 25);
-            this.comboBox_startDate.TabIndex = 3;
+            comboBox_startDate.FormattingEnabled = true;
+            comboBox_startDate.Location = new System.Drawing.Point(135, 55);
+            comboBox_startDate.Name = "comboBox_startDate";
+            comboBox_startDate.Size = new System.Drawing.Size(154, 25);
+            comboBox_startDate.TabIndex = 3;
             // 
             // label_taskName
             // 
-            this.label_taskName.AutoSize = true;
-            this.label_taskName.Location = new System.Drawing.Point(9, 45);
-            this.label_taskName.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_taskName.Name = "label_taskName";
-            this.label_taskName.Size = new System.Drawing.Size(74, 17);
-            this.label_taskName.TabIndex = 1;
-            this.label_taskName.Text = "Task Name";
+            label_taskName.AutoSize = true;
+            label_taskName.Location = new System.Drawing.Point(6, 27);
+            label_taskName.Name = "label_taskName";
+            label_taskName.Size = new System.Drawing.Size(74, 17);
+            label_taskName.TabIndex = 1;
+            label_taskName.Text = "Task Name";
             // 
             // comboBox_taskName
             // 
-            this.comboBox_taskName.FormattingEnabled = true;
-            this.comboBox_taskName.Location = new System.Drawing.Point(193, 40);
-            this.comboBox_taskName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.comboBox_taskName.Name = "comboBox_taskName";
-            this.comboBox_taskName.Size = new System.Drawing.Size(218, 25);
-            this.comboBox_taskName.TabIndex = 3;
+            comboBox_taskName.FormattingEnabled = true;
+            comboBox_taskName.Location = new System.Drawing.Point(135, 24);
+            comboBox_taskName.Name = "comboBox_taskName";
+            comboBox_taskName.Size = new System.Drawing.Size(154, 25);
+            comboBox_taskName.TabIndex = 3;
             // 
             // label_taskSetup
             // 
-            this.label_taskSetup.AutoSize = true;
-            this.label_taskSetup.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.label_taskSetup.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.label_taskSetup.Location = new System.Drawing.Point(10, 27);
-            this.label_taskSetup.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label_taskSetup.Name = "label_taskSetup";
-            this.label_taskSetup.Size = new System.Drawing.Size(202, 32);
-            this.label_taskSetup.TabIndex = 0;
-            this.label_taskSetup.Text = "Task Data Import";
+            label_taskSetup.AutoSize = true;
+            label_taskSetup.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold);
+            label_taskSetup.ForeColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            label_taskSetup.Location = new System.Drawing.Point(7, 16);
+            label_taskSetup.Name = "label_taskSetup";
+            label_taskSetup.Size = new System.Drawing.Size(202, 32);
+            label_taskSetup.TabIndex = 0;
+            label_taskSetup.Text = "Task Data Import";
             // 
             // button_taskSelectFile
             // 
-            this.button_taskSelectFile.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(43)))), ((int)(((byte)(141)))));
-            this.button_taskSelectFile.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.button_taskSelectFile.FlatAppearance.BorderSize = 0;
-            this.button_taskSelectFile.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_taskSelectFile.ForeColor = System.Drawing.Color.White;
-            this.button_taskSelectFile.Location = new System.Drawing.Point(19, 185);
-            this.button_taskSelectFile.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button_taskSelectFile.Name = "button_taskSelectFile";
-            this.button_taskSelectFile.Size = new System.Drawing.Size(114, 48);
-            this.button_taskSelectFile.TabIndex = 4;
-            this.button_taskSelectFile.Text = "Select File";
-            this.defaultToolTip.SetToolTip(this.button_taskSelectFile, "Select input CSV file");
-            this.button_taskSelectFile.UseVisualStyleBackColor = false;
-            this.button_taskSelectFile.Click += new System.EventHandler(this.button_select_task_file_Click);
+            button_taskSelectFile.BackColor = System.Drawing.Color.FromArgb(226, 43, 141);
+            button_taskSelectFile.Cursor = System.Windows.Forms.Cursors.Hand;
+            button_taskSelectFile.FlatAppearance.BorderSize = 0;
+            button_taskSelectFile.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            button_taskSelectFile.ForeColor = System.Drawing.Color.White;
+            button_taskSelectFile.Location = new System.Drawing.Point(13, 111);
+            button_taskSelectFile.Name = "button_taskSelectFile";
+            button_taskSelectFile.Size = new System.Drawing.Size(80, 29);
+            button_taskSelectFile.TabIndex = 4;
+            button_taskSelectFile.Text = "Select File";
+            defaultToolTip.SetToolTip(button_taskSelectFile, "Select input CSV file");
+            button_taskSelectFile.UseVisualStyleBackColor = false;
+            button_taskSelectFile.Click += button_select_task_file_Click;
             // 
             // tmrExpand
             // 
-            this.tmrExpand.Interval = 10;
-            this.tmrExpand.Tick += new System.EventHandler(this.tmrExpand_Tick);
+            tmrExpand.Interval = 10;
+            tmrExpand.Tick += tmrExpand_Tick;
             // 
             // defaultToolTip
             // 
-            this.defaultToolTip.ShowAlways = true;
+            defaultToolTip.ShowAlways = true;
             // 
             // UserControl_TaskImport
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.panel_taskFieldMapping);
-            this.Controls.Add(this.panel_taskButtons);
-            this.Controls.Add(this.panel_projectMessage);
-            this.Controls.Add(this.panel_taskDataTable);
-            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.Name = "UserControl_TaskImport";
-            this.Size = new System.Drawing.Size(1437, 1070);
-            this.Load += new System.EventHandler(this.UserControl1_Load);
-            this.panel_taskDataTable.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridView_task)).EndInit();
-            this.panel_projectMessage.ResumeLayout(false);
-            this.panel_projectMessage.PerformLayout();
-            this.panel_taskButtons.ResumeLayout(false);
-            this.panel_taskFieldMapping.ResumeLayout(false);
-            this.panel_taskFieldMapping.PerformLayout();
-            this.flowLayoutPanel_nonMandatoryFields.ResumeLayout(false);
-            this.panel_NonMandatoryButton.ResumeLayout(false);
-            this.panel_NonMandatoryButton.PerformLayout();
-            this.panel_NonMandatoryFields.ResumeLayout(false);
-            this.panel_NonMandatoryFields.PerformLayout();
-            this.panel1.ResumeLayout(false);
-            this.panel1.PerformLayout();
-            this.groupBox_taskMandatoryFields.ResumeLayout(false);
-            this.groupBox_taskMandatoryFields.PerformLayout();
-            this.ResumeLayout(false);
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(panel_taskFieldMapping);
+            Controls.Add(panel_taskButtons);
+            Controls.Add(panel_projectMessage);
+            Controls.Add(panel_taskDataTable);
+            Name = "UserControl_TaskImport";
+            Size = new System.Drawing.Size(1006, 642);
+            Load += UserControl1_Load;
+            panel_taskDataTable.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)dataGridView_task).EndInit();
+            panel_projectMessage.ResumeLayout(false);
+            panel_projectMessage.PerformLayout();
+            panel_taskButtons.ResumeLayout(false);
+            panel_taskFieldMapping.ResumeLayout(false);
+            panel_taskFieldMapping.PerformLayout();
+            flowLayoutPanel_nonMandatoryFields.ResumeLayout(false);
+            panel_NonMandatoryButton.ResumeLayout(false);
+            panel_NonMandatoryButton.PerformLayout();
+            panel_NonMandatoryFields.ResumeLayout(false);
+            panel_NonMandatoryFields.PerformLayout();
+            panel1.ResumeLayout(false);
+            panel1.PerformLayout();
+            groupBox_taskMandatoryFields.ResumeLayout(false);
+            groupBox_taskMandatoryFields.PerformLayout();
+            ResumeLayout(false);
 
         }
 

--- a/UserControls/UserControl_TaskImport.resx
+++ b/UserControls/UserControl_TaskImport.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -57,4 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="WorkerFetcher.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="defaultToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>259, 17</value>
+  </metadata>
+  <metadata name="tmrExpand.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>148, 17</value>
+  </metadata>
 </root>

--- a/UserControls/UserControl_TimeregistrationImport.Designer.cs
+++ b/UserControls/UserControl_TimeregistrationImport.Designer.cs
@@ -373,6 +373,7 @@
             // 
             // comboBox_delimiter
             // 
+            comboBox_delimiter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             comboBox_delimiter.FormattingEnabled = true;
             comboBox_delimiter.Location = new System.Drawing.Point(82, 72);
             comboBox_delimiter.Name = "comboBox_delimiter";


### PR DESCRIPTION
All our delimiter comboboxes where set to the DropDown style, this allows the user to manually input what ever they want and not only select the allowed values. If they do this it breaks when they try to select a file since the delimiter is given as a input. To fix this the style has been changed to DropDownList.